### PR TITLE
stanli.sty: Use stanli's 3dplot defs only as fallback, load tikz-3dplot/3dplot packages if available.

### DIFF
--- a/stanli.sty
+++ b/stanli.sty
@@ -2014,6 +2014,26 @@
 	
 }
 
+% ================================================
+% Some definitions below are borrowed from tikz-3dplot/3dplot packages.
+% Use stanli's own copy only if they are not available.
+% ================================================
+
+\IfFileExists{tikz-3dplot.sty}{% Current package name at CTAN
+  \RequirePackage{tikz-3dplot}%
+  \expandafter\endinput%
+}{
+  \message{stanli: tikz-3dplot package not found. Trying 3dplot.}
+}
+
+\IfFileExists{3dplot.sty}{% Old package name
+  \RequirePackage{3dplot}%
+  \expandafter\endinput%
+}{
+  \message{stanli: 3dplot package not found.}
+}
+
+\message{stanli: None of tikz-3dplot or 3dplot packages found. Using stanli's own definitions.}
 
 %================================================
 %		Commands from 3dplot.sty by Jeff Hein 2009


### PR DESCRIPTION
Hi, Jürgen,

Thanks for this project. I started using it recently and found a problem when tikz-3dplot is also loaded.

stanli.sty provides a copy of some 3dplot definitions. However, the way it is handled is incompatible with the use of {tikz-,}3dplot in the same document, causing errors

! LaTeX Error: Command \tdplotsinandcos already defined.
               Or name \end... illegal, see p.192 of the manual.

This patch checks for tikz-3dplot/3dplot existence and requires them if available. Since this part exits stanli.sty on success, stanli's own copy of the definitions will only be used as fallback.

No problem if tikz-3dplot/3dplot package is already loaded, \RequirePackage will not try to load it again.

Current patch is not too versatile, you cannot add new non 3dplot code after the tests, but at least it shows the problem.