### PR TITLE
\support{5c}: Alternative representation for linear spring as a coil.

### DIFF
--- a/stanli.sty
+++ b/stanli.sty
@@ -85,6 +85,11 @@
 \newcommand{\springPostLength}{3pt}			%
 \newcommand{\springAmplitude}{2.5mm}		%
 \newcommand{\springSegmentLength}{5pt}	%
+\newcommand{\springCoilLength}{10mm}      	%
+\newcommand{\springCoilPreLength}{3pt}      %
+\newcommand{\springCoilPostLength}{1pt}			%
+\newcommand{\springCoilAmplitude}{2.5mm}		%
+\newcommand{\springCoilSegmentLength}{3pt}	%
 
 \newcommand{\supportGap}{1mm}						%
 \newcommand{\supportBasicLength}{12mm}	%
@@ -146,7 +151,7 @@
 \tikzstyle{tinyLine}=[line width=\tinyLineWidth,]
 
 %------------------------------------------------
-%		spring style
+%		spring styles
 %------------------------------------------------
 
 \tikzstyle{spring} =	[
@@ -158,6 +163,19 @@
 			post length=\springPostLength,
 			segment length=\springSegmentLength,
 			amplitude=\springAmplitude
+		},
+		decorate,
+]
+                
+\tikzstyle{coilspring} =	[
+	normalLine,
+	decoration=
+		{
+			coil,
+			pre length=\springCoilPreLength,
+			post length=\springCoilPostLength,
+			segment length=\springCoilSegmentLength,
+			amplitude=\springCoilAmplitude
 		},
 		decorate,
 ]
@@ -382,13 +400,29 @@
 		\end{scope}
 	}{}
 	
-	\ifthenelse{\equal{#1}{5}}{		%
+	\ifthenelse{\equal{#1}{5}}{ % Linear spring with zig-zag
 		\begin{scope}[rotate around={#3:(#2)}]
 			\draw [spring] (#2) -- ++(0,-\springLength);
 			\draw [normalLine] ($(#2)+1*(\supportBasicLength/2,-\springLength)$) -- ++(-\supportBasicLength,0);
 			\clip ($(#2)+1*(-\supportBasicLength/2,-\supportBasicHeight-\springLength)$) rectangle ($(#2)+1*(\supportBasicLength/2,-\springLength)$);
 			\draw[hatching]($(#2)+1*(\supportHatchingLength/2,-\springLength)$) -- ++(-\supportHatchingLength,0);
 		\end{scope}
+	}{}
+	
+	\ifthenelse{\equal{#1}{5c}}{ % Linear spring with coil
+          \begin{scope}[rotate around={#3:(#2)}]
+            \draw [coilspring]
+              (#2) -- ++(0,-\springCoilLength);
+            \draw [normalLine]
+              ($(#2)+1*(\supportBasicLength/2,-\springLength)$)
+              -- ++(-\supportBasicLength,0);
+            \clip
+              ($(#2)+1*(-\supportBasicLength/2,-\supportBasicHeight-\springLength)$)
+              rectangle ($(#2)+1*(\supportBasicLength/2,-\springLength)$);
+            \draw[hatching]
+              ($(#2)+1*(\supportHatchingLength/2,-\springLength)$)
+              -- ++(-\supportHatchingLength,0);
+          \end{scope}
 	}{}
 
 	\ifthenelse{\equal{#1}{6}}{		%

--- a/stanli.tex
+++ b/stanli.tex
@@ -1166,21 +1166,28 @@ Two variants are available, (\texttt{4}) with a slider and (\texttt{4ooo}) with 
 \endgroup
 
 \begingroup
-\hspace{7mm}\lstinline[emph={support}]|\support{5}{insertion point}[rotation];|
-
-
+\begin{lstlisting}[emph={support},backgroundcolor=\color{white},xleftmargin=7mm,belowskip=-0.5cm]
+\support{5}{insertion point}[rotation];
+\support{5c}{insertion point}[rotation];
+\end{lstlisting}
 \leftskip=14mm Type $5$ describes a spring.
+Two alternative representations are available, (\texttt{5}) will use a
+zig-zag line and (\texttt{5c}) a coil.
 
 \leftskip=14mm\begin{minipage}[c]{0.3\linewidth}
 	\begin{tikzpicture}[framed]
 			\point{a}{0}{0};
+			\point{b}{2}{0};
 			\support{5}{a};
+			\support{5c}{b};
 	\end{tikzpicture}
 \end{minipage}
 \begin{minipage}{0.61\linewidth}\begin{lstlisting}
 	\begin{tikzpicture}
 		\point{a}{0}{0};
+		\point{b}{2}{0};
 		\support{5}{a};
+		\support{5c}{b};
 	\end{tikzpicture}\end{lstlisting}\vspace{-7mm}
 \end{minipage}
 


### PR DESCRIPTION
Hi,

I have been also playing with another representation for linear springs as coils. Please see attached patch. 

As before, I did not refresh stanli.pdf (I expect this to make merges simpler), 

Once refreshed, associated entry in stanli.pdf should look like

![image](https://user-images.githubusercontent.com/33841417/33550612-e4a12f12-d8ee-11e7-8bce-b28d1c665103.png)
