### PR TITLE
stanli.sty: Fine tune fixed bearing height to match floating bearings

### DIFF
--- a/stanli.sty
+++ b/stanli.sty
@@ -276,10 +276,17 @@
 \newcommandx{\support}[3][3=0]{
 	\ifthenelse{\equal{#1}{1}}{		%
 		\begin{scope}[rotate around={#3:(#2)}]
-			\draw [normalLine] (#2) -- ++(\supportLength/2,-\supportHeight) -- ++(-\supportLength,0) -- cycle;
-			\draw [normalLine] ($(#2)+1*(\supportBasicLength/2,-\supportHeight)$) -- ++(-\supportBasicLength,0);
-			\clip ($(#2)+1*(-\supportBasicLength/2,-\supportBasicHeight-\supportHeight)$) rectangle ($(#2)+1*(\supportBasicLength/2,-\supportHeight)$);
-			\draw[hatching]($(#2)+1*(\supportHatchingLength/2,-\supportHatchingHeight)$) -- ++(-\supportHatchingLength,0);
+                        \draw [normalLine] (#2)
+                          -- ++(\supportLength/2,-\supportHeight-\supportGap)
+                          -- ++(-\supportLength,0) -- cycle;
+                        \draw [normalLine] ($(#2)+1*(\supportBasicLength/2,-\supportHeight-\supportGap)$)
+                          -- ++(-\supportBasicLength,0);
+                        \clip
+                          ($(#2)+1*(-\supportBasicLength/2,-\supportBasicHeight-\supportHeight-\supportGap)$)
+                          rectangle ($(#2)+1*(\supportBasicLength/2,-\supportHeight-\supportGap)$);
+                        \draw[hatching]
+                          ($(#2)+1*(\supportHatchingLength/2,-\supportHatchingHeight-\supportGap)$)
+                          -- ++(-\supportHatchingLength,0);
 		\end{scope}
 	}{}
 


### PR DESCRIPTION
Hi,

This is a minor cosmetic suggestion. Distance from point to ground is slightly different between fixed bearings and floating bearings (in \supportGap). I think that having them similar looks better. I considered changing \supportHeight  to match that point to ground distance and change everything accordingly, but seemed to invasive, so I am proposing this change that only affects fixed support definition.

I am attaching am image with the differences between before (above) and after. This can also be seen in examples in section 4.1.4 of stanli.pdf

![image](https://user-images.githubusercontent.com/33841417/33551696-767e5c72-d8f2-11e7-9774-4abbe07ffe42.png)

As before, I did not refresh stanli.pdf.

Regards,