### PR TITLE
Better SI compliance and decimal separators

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -237,13 +237,13 @@ in a very short time: ::
      \dlineload{5}{0}{h}{d}[.5][.5][.11];
      \dlineload{5}{0}{d}{j}[.5][.5][.11];
 
-     \ddimensioning{xy}{f}{g}{4.5}[$3~m$];
-     \ddimensioning{xy}{g}{h}{4.5}[$3~m$];
-     \ddimensioning{xy}{h}{i}{4.5}[$3~m$];
-     \ddimensioning{xy}{i}{j}{4.5}[$3~m$];
-     \ddimensioning{yx}{e}{j}{13}[$3~m$];
+     \ddimensioning{xy}{f}{g}{4.5}[$3$\,m];
+     \ddimensioning{xy}{g}{h}{4.5}[$3$\,m];
+     \ddimensioning{xy}{h}{i}{4.5}[$3$\,m];
+     \ddimensioning{xy}{i}{j}{4.5}[$3$\,m];
+     \ddimensioning{yx}{e}{j}{13}[$3$\,m];
 
-     \dnotation{1}{f}{$q=10~kN/m$}[above left=3mm];
+     \dnotation{1}{f}{$q=10$\,kN/m}[above left=3mm];
      \dnotation{1}{b}{$A$}[below left];
      \dnotation{1}{h}{$C$}[right=2mm];
      \dnotation{1}{d}{$B$}[below left];

--- a/README.rst
+++ b/README.rst
@@ -162,13 +162,13 @@ in a very short time: ::
      \lineload{2}{a}{b}[1][1][.5];
      \lineload{2}{b}{c};
 
-     \dimensioning{1}{a}{b}{-2.5}[$3,0$];
-     \dimensioning{1}{b}{c}{-2.5}[$8,0$];
-     \dimensioning{1}{c}{d}{-2.5}[$8,0$];
-     \dimensioning{1}{d}{e}{-2.5}[$3,0$];
-     \dimensioning{2}{f}{a}{-1}[$1,0$];
-     \dimensioning{2}{g}{f}{-1}[$2,0$];
-     \dimensioning{2}{a}{c}{-1}[$2,0$];
+     \dimensioning{1}{a}{b}{-2.5}[$3.0$];
+     \dimensioning{1}{b}{c}{-2.5}[$8.0$];
+     \dimensioning{1}{c}{d}{-2.5}[$8.0$];
+     \dimensioning{1}{d}{e}{-2.5}[$3.0$];
+     \dimensioning{2}{f}{a}{-1}[$1.0$];
+     \dimensioning{2}{g}{f}{-1}[$2.0$];
+     \dimensioning{2}{a}{c}{-1}[$2.0$];
 
      \influenceline{a}{e}{3}[.3];
 

--- a/example.tex
+++ b/example.tex
@@ -51,13 +51,13 @@
 	\lineload{2}{a}{b}[1][1][.5];
 	\lineload{2}{b}{c};
 	
-	\dimensioning{1}{a}{b}{-2.5}[$3,0$];
-	\dimensioning{1}{b}{c}{-2.5}[$8,0$];
-	\dimensioning{1}{c}{d}{-2.5}[$8,0$];
-	\dimensioning{1}{d}{e}{-2.5}[$3,0$];
-	\dimensioning{2}{f}{a}{-1}[$1,0$];
-	\dimensioning{2}{g}{f}{-1}[$2,0$];
-	\dimensioning{2}{a}{c}{-1}[$2,0$];
+	\dimensioning{1}{a}{b}{-2.5}[$3.0$];
+	\dimensioning{1}{b}{c}{-2.5}[$8.0$];
+	\dimensioning{1}{c}{d}{-2.5}[$8.0$];
+	\dimensioning{1}{d}{e}{-2.5}[$3.0$];
+	\dimensioning{2}{f}{a}{-1}[$1.0$];
+	\dimensioning{2}{g}{f}{-1}[$2.0$];
+	\dimensioning{2}{a}{c}{-1}[$2.0$];
 	
 	\influenceline{a}{e}{3}[.3];
 	

--- a/example.tex
+++ b/example.tex
@@ -119,13 +119,13 @@
 \dlineload{5}{0}{h}{d}[.5][.5][.11];
 \dlineload{5}{0}{d}{j}[.5][.5][.11];
 
-\ddimensioning{xy}{f}{g}{4.5}[$3~m$];
-\ddimensioning{xy}{g}{h}{4.5}[$3~m$];
-\ddimensioning{xy}{h}{i}{4.5}[$3~m$];
-\ddimensioning{xy}{i}{j}{4.5}[$3~m$];
-\ddimensioning{yx}{e}{j}{13}[$3~m$];
+\ddimensioning{xy}{f}{g}{4.5}[$3$\,m];
+\ddimensioning{xy}{g}{h}{4.5}[$3$\,m];
+\ddimensioning{xy}{h}{i}{4.5}[$3$\,m];
+\ddimensioning{xy}{i}{j}{4.5}[$3$\,m];
+\ddimensioning{yx}{e}{j}{13}[$3$\,m];
 
-\dnotation{1}{f}{$q=10~kN/m$}[above left=3
+\dnotation{1}{f}{$q=10$\,kN/m}[above left=3
 mm];
 \dnotation{1}{b}{$A$}[below left];
 \dnotation{1}{h}{$C$}[right=2mm];

--- a/stanli.tex
+++ b/stanli.tex
@@ -1704,16 +1704,16 @@ Here the angle is counted from the x-axis.
 			\point{c}{4}{.5};
 			\beam{1}{a}{b}[0][1];
 			\beam{1}{b}{c}[1];
-			\dimensioning{1}{a}{b}{-.5}[$2~m$];
-			\dimensioning{1}{b}{c}{-.5}[$2~m$];
+			\dimensioning{1}{a}{b}{-.5}[$2$\,m];
+			\dimensioning{1}{b}{c}{-.5}[$2$\,m];
 	\end{tikzpicture}
 \end{minipage}
 \begin{minipage}{0.61\linewidth}\begin{lstlisting}
 	\begin{tikzpicture}
 		\point{a}{0}{0};	\point{b}{2}{1};	\point{c}{4}{.5};
 		\beam{1}{a}{b}[0][1];	\beam{1}{b}{c}[1];
-		\dimensioning{1}{a}{b}{-.5}[$2~m$];
-		\dimensioning{1}{b}{c}{-.5}[$2~m$];
+		\dimensioning{1}{a}{b}{-.5}[$2$\,m];
+		\dimensioning{1}{b}{c}{-.5}[$2$\,m];
 	\end{tikzpicture}\end{lstlisting}\vspace{-7mm}
 \end{minipage}
 
@@ -1729,7 +1729,7 @@ Here the angle is counted from the x-axis.
 			\point{a}{0}{0};
 			\point{b}{2}{1};
 			\beam{1}{a}{b};
-			\dimensioning{2}{a}{b}{-.5}[$1~m$];
+			\dimensioning{2}{a}{b}{-.5}[$1$\,m];
 	\end{tikzpicture}
 \end{minipage}
 \begin{minipage}{0.61\linewidth}\begin{lstlisting}
@@ -1737,7 +1737,7 @@ Here the angle is counted from the x-axis.
 		\point{a}{0}{0};
 		\point{b}{2}{1};
 		\beam{1}{a}{b};
-		\dimensioning{2}{a}{b}{-.5}[$1~m$];
+		\dimensioning{2}{a}{b}{-.5}[$1$\,m];
 	\end{tikzpicture}\end{lstlisting}\vspace{-7mm}
 \end{minipage}
 
@@ -3946,10 +3946,10 @@ Type $3$ describes a local axis in space. Contrary to type $2$ not the plane but
 		\dpoint{c}{1.5}{3}{-1};
 		\dbeam{1}{a}{b}[0][1];
 		\dbeam{1}{b}{c};
-		\ddimensioning{yz}{a}{b}{.5}[$3m$];
-		\ddimensioning{zy}{a}{b}{3.3}[$1m$];
-		\ddimensioning{xz}[3]{b}{c}{.5}[$1.5m$][1.5];
-		\ddimensioning{xy}[-1]{b}{c}{0}[$1.5m$][3];
+		\ddimensioning{yz}{a}{b}{.5}[$3$\,m];
+		\ddimensioning{zy}{a}{b}{3.3}[$1$\,m];
+		\ddimensioning{xz}[3]{b}{c}{.5}[$1.5$\,m][1.5];
+		\ddimensioning{xy}[-1]{b}{c}{0}[$1.5$\,m][3];
 	\end{tikzpicture}
 \end{minipage}
 \begin{minipage}{0.61\linewidth}\begin{lstlisting}
@@ -3959,10 +3959,10 @@ Type $3$ describes a local axis in space. Contrary to type $2$ not the plane but
 		\dpoint{c}{1.5}{3}{-1};
 		\dbeam{1}{a}{b}[0][1];	
 		\dbeam{1}{b}{c};
-		\ddimensioning{yz}{a}{b}{.5}[$3m$];
-		\ddimensioning{zy}{a}{b}{3.3}[$1m$];
-		\ddimensioning{xz}[3]{b}{c}{.5}[$1.5m$][1.5];
-		\ddimensioning{xy}[-1]{b}{c}{0}[$1.5m$][3];
+		\ddimensioning{yz}{a}{b}{.5}[$3$\,m];
+		\ddimensioning{zy}{a}{b}{3.3}[$1$\,m];
+		\ddimensioning{xz}[3]{b}{c}{.5}[$1.5$\,m][1.5];
+		\ddimensioning{xy}[-1]{b}{c}{0}[$1.5$\,m][3];
 	\end{tikzpicture}\end{lstlisting}\vspace{-7mm}
 \end{minipage}
 
@@ -4785,13 +4785,13 @@ In this tutorial, the basic principles of designing 3D structures with \tikzsym 
 	\dlineload{5}{0}{h}{d}[.5][.5][.11];
 	\dlineload{5}{0}{d}{j}[.5][.5][.11];
 
-	\ddimensioning{xy}{f}{g}{4.5}[$3~m$];
-	\ddimensioning{xy}{g}{h}{4.5}[$3~m$];
-	\ddimensioning{xy}{h}{i}{4.5}[$3~m$];
-	\ddimensioning{xy}{i}{j}{4.5}[$3~m$];
-	\ddimensioning{yx}{e}{j}{13}[$3~m$];
+	\ddimensioning{xy}{f}{g}{4.5}[$3$\,m];
+	\ddimensioning{xy}{g}{h}{4.5}[$3$\,m];
+	\ddimensioning{xy}{h}{i}{4.5}[$3$\,m];
+	\ddimensioning{xy}{i}{j}{4.5}[$3$\,m];
+	\ddimensioning{yx}{e}{j}{13}[$3$\,m];
 
-	\dnotation{1}{f}{$q=10~kN/m$}[above left=3mm];
+	\dnotation{1}{f}{$q=10$\,kN/m}[above left=3mm];
 	\dnotation{1}{b}{$A$}[below left];
 	\dnotation{1}{h}{$C$}[right=2mm];
 	\dnotation{1}{d}{$B$}[below left];
@@ -5105,18 +5105,18 @@ Actually, the structural design is already finished and ready for use. However, 
 	\dlineload{5}{0}{h}{d}[.5][.5][.11];
 	\dlineload{5}{0}{d}{j}[.5][.5][.11];
 
-	\ddimensioning{xy}{f}{g}{4.5}[$3~m$];
-	\ddimensioning{xy}{g}{h}{4.5}[$3~m$];
-	\ddimensioning{xy}{h}{i}{4.5}[$3~m$];
-	\ddimensioning{xy}{i}{j}{4.5}[$3~m$];
-	\ddimensioning{yx}{e}{j}{13}[$3~m$];
+	\ddimensioning{xy}{f}{g}{4.5}[$3$\,m];
+	\ddimensioning{xy}{g}{h}{4.5}[$3$\,m];
+	\ddimensioning{xy}{h}{i}{4.5}[$3$\,m];
+	\ddimensioning{xy}{i}{j}{4.5}[$3$\,m];
+	\ddimensioning{yx}{e}{j}{13}[$3$\,m];
 \end{tikzpicture}
 
 \begin{lstlisting}
 % Dimensions
-	\ddimensioning{xy}{f}{g}{4.5}[$3~m$];				\ddimensioning{xy}{g}{h}{4.5}[$3~m$];
-	\ddimensioning{xy}{h}{i}{4.5}[$3~m$];				\ddimensioning{xy}{i}{j}{4.5}[$3~m$];
-	\ddimensioning{yx}{e}{j}{13}[$3~m$];
+	\ddimensioning{xy}{f}{g}{4.5}[$3$\,m];				\ddimensioning{xy}{g}{h}{4.5}[$3$\,m];
+	\ddimensioning{xy}{h}{i}{4.5}[$3$\,m];				\ddimensioning{xy}{i}{j}{4.5}[$3$\,m];
+	\ddimensioning{yx}{e}{j}{13}[$3$\,m];
 \end{lstlisting}\vspace*{-7mm}
 
 \vspace*{-5mm}
@@ -5168,13 +5168,13 @@ Now the only missing parts are the names of nodes and bars, then the constructio
 	\dlineload{5}{0}{h}{d}[.5][.5][.11];
 	\dlineload{5}{0}{d}{j}[.5][.5][.11];
 
-	\ddimensioning{xy}{f}{g}{4.5}[$3~m$];
-	\ddimensioning{xy}{g}{h}{4.5}[$3~m$];
-	\ddimensioning{xy}{h}{i}{4.5}[$3~m$];
-	\ddimensioning{xy}{i}{j}{4.5}[$3~m$];
-	\ddimensioning{yx}{e}{j}{13}[$3~m$];
+	\ddimensioning{xy}{f}{g}{4.5}[$3$\,m];
+	\ddimensioning{xy}{g}{h}{4.5}[$3$\,m];
+	\ddimensioning{xy}{h}{i}{4.5}[$3$\,m];
+	\ddimensioning{xy}{i}{j}{4.5}[$3$\,m];
+	\ddimensioning{yx}{e}{j}{13}[$3$\,m];
 
-	\dnotation{1}{f}{$q=10~kN/m$}[above left=3mm];
+	\dnotation{1}{f}{$q=10$\,kN/m}[above left=3mm];
 	\dnotation{1}{b}{$A$}[below left];
 	\dnotation{1}{h}{$C$}[right=2mm];
 	\dnotation{1}{d}{$B$}[below left];
@@ -5182,7 +5182,7 @@ Now the only missing parts are the names of nodes and bars, then the constructio
 
 \begin{lstlisting}
 % Labels
-	\dnotation{1}{f}{$q=10~kN/m$}[above left=3mm];			\dnotation{1}{b}{$A$}[below left];
+	\dnotation{1}{f}{$q=10$\,kN/m}[above left=3mm];			\dnotation{1}{b}{$A$}[below left];
 	\dnotation{1}{h}{$C$}[right=2mm];										\dnotation{1}{d}{$B$}[below left];
 \end{lstlisting}\vspace*{-7mm}
 
@@ -5233,13 +5233,13 @@ Now the point labeling can be switched off and the construction is finished.
 	\dlineload{5}{0}{h}{d}[.5][.5][.11];
 	\dlineload{5}{0}{d}{j}[.5][.5][.11];
 
-	\ddimensioning{xy}{f}{g}{4.5}[$3~m$];
-	\ddimensioning{xy}{g}{h}{4.5}[$3~m$];
-	\ddimensioning{xy}{h}{i}{4.5}[$3~m$];
-	\ddimensioning{xy}{i}{j}{4.5}[$3~m$];
-	\ddimensioning{yx}{e}{j}{13}[$3~m$];
+	\ddimensioning{xy}{f}{g}{4.5}[$3$\,m];
+	\ddimensioning{xy}{g}{h}{4.5}[$3$\,m];
+	\ddimensioning{xy}{h}{i}{4.5}[$3$\,m];
+	\ddimensioning{xy}{i}{j}{4.5}[$3$\,m];
+	\ddimensioning{yx}{e}{j}{13}[$3$\,m];
 
-	\dnotation{1}{f}{$q=10~kN/m$}[above left=3mm];
+	\dnotation{1}{f}{$q=10$\,kN/m}[above left=3mm];
 	\dnotation{1}{b}{$A$}[below left];
 	\dnotation{1}{h}{$C$}[right=2mm];
 	\dnotation{1}{d}{$B$}[below left];
@@ -5303,14 +5303,14 @@ Now the point labeling can be switched off and the construction is finished.
 	\dlineload{5}{0}{d}{j}[.5][.5][.11];
 
 % Dimensions
-	\ddimensioning{xy}{f}{g}{4.5}[$3~m$];
-	\ddimensioning{xy}{g}{h}{4.5}[$3~m$];
-	\ddimensioning{xy}{h}{i}{4.5}[$3~m$];
-	\ddimensioning{xy}{i}{j}{4.5}[$3~m$];
-	\ddimensioning{yx}{e}{j}{13}[$3~m$];
+	\ddimensioning{xy}{f}{g}{4.5}[$3$\,m];
+	\ddimensioning{xy}{g}{h}{4.5}[$3$\,m];
+	\ddimensioning{xy}{h}{i}{4.5}[$3$\,m];
+	\ddimensioning{xy}{i}{j}{4.5}[$3$\,m];
+	\ddimensioning{yx}{e}{j}{13}[$3$\,m];
 
 % Labels
-	\dnotation{1}{f}{$q=10~kN/m$}[above left=3mm];
+	\dnotation{1}{f}{$q=10$\,kN/m}[above left=3mm];
 	\dnotation{1}{b}{$A$}[below left];
 	\dnotation{1}{h}{$C$}[right=2mm];
 	\dnotation{1}{d}{$B$}[below left];

--- a/stanli.tex
+++ b/stanli.tex
@@ -1625,16 +1625,16 @@ Here the angle is counted from the x-axis.
 			\point{b}{4}{0};
 			\beam{1}{a}{b};
 			\temperature{a}{b}{-.5}{.5}[.3][$T_i$][$T_a$];
-			\temperature{a}{b}{.2}{.7}[.6][$10°C$][$30°C$];
+			\temperature{a}{b}{.2}{.7}[.6][$10\,{}°$C][$30\,{}°$C];
 	\end{tikzpicture}
 \end{minipage}
-\begin{minipage}{0.61\linewidth}\begin{lstlisting}
+\begin{minipage}{0.63\linewidth}\begin{lstlisting}
 	\begin{tikzpicture}
 		\point{a}{0}{0};
 		\point{b}{4}{0};
 		\beam{1}{a}{b};
 		\temperature{a}{b}{-.5}{.5}[.3][$T_i$][$T_a$];
-		\temperature{a}{b}{.2}{.7}[.6][$10°C$][$30°C$];
+		\temperature{a}{b}{.2}{.7}[.6][$10\,{}°$C][$30\,{}°$C];
 	\end{tikzpicture}\end{lstlisting}\vspace{-7mm}
 \end{minipage}
 

--- a/stanli.tex
+++ b/stanli.tex
@@ -880,7 +880,7 @@ For illustration a small example of a single force
 \end{lstlisting} 
 
 
-When entering size values the base unit is always predefined in $[cm]$.  Percentage values $\%$ are always specified as decimal values; for example, $100\% = 1.0 $ and $ 10 \% $ corresponds to $ 0.1 $.
+When entering size values the base unit is always predefined in $[\mathrm{cm}]$.  Percentage values $\%$ are always specified as decimal values; for example, $100\% = 1.0 $ and $ 10 \% $ corresponds to $ 0.1 $.
 
 Another important note is, that every \tikzsym command has to be completed with an semicolon ``;''. If this semicolon is not set, the command can not be performed, this leads finally to an error message by the compilation.
 
@@ -2407,7 +2407,7 @@ In order to create the desired roof structure, a file has to be created first. I
 \subsection{First steps}
 \label{sec:ErsteSchritte}
 
-First, we have to specify corresponding points with the command \lstinline|\point|. On this basis, the remaining library elements are placed. Since the points are not shown in the graph, it is recommended to create a helping grid, to predict the distances and sizes. The basic size of a grid element is $1~cm $ by $1 ~cm $.
+First, we have to specify corresponding points with the command \lstinline|\point|. On this basis, the remaining library elements are placed. Since the points are not shown in the graph, it is recommended to create a helping grid, to predict the distances and sizes. The basic size of a grid element is $1\,\mathrm{cm}$ by $1\,\mathrm{cm}$.
 
 \begin{minipage}[c]{0.65\linewidth}
 	\begin{tikzpicture}[framed]
@@ -2421,7 +2421,7 @@ First, we have to specify corresponding points with the command \lstinline|\poin
 \end{tikzpicture}\end{lstlisting}\vspace{-7mm}
 \end{minipage}
 
-Here, it is obvious that the roof structure with a width of $ 22 ~cm $ does not fit on this page. In order not to change all the dimensions recalculating all distances, the command \lstinline|scaling| can be used. Hereby, the distances are scaled depending on the desired scaling factor. However, the symbols and the entries remain unchanged. 
+Here, it is obvious that the roof structure with a width of $22\,\mathrm{cm}$ does not fit on this page. In order not to change all the dimensions recalculating all distances, the command \lstinline|scaling| can be used. Hereby, the distances are scaled depending on the desired scaling factor. However, the symbols and the entries remain unchanged. 
 
 Note, since the help grid is a function of \tikzsym, the scaling command can not be used for the guides. If we recalculate the size of the grid we get following situation:
 
@@ -2978,7 +2978,7 @@ For illustration a small example of a single force
 	\dload{type}{insertion point}[rotation A][rotation B][load length][load distance];
 \end{lstlisting} 
 
-When entering size values the base unit is always predefined in $[cm]$.  Percentage values $\%$ are always specified as decimal values; for example, $100\% = 1.0 $ and $ 10 \% $ corresponds to $ 0.1 $.
+When entering size values the base unit is always predefined in $[\mathrm{cm}]$.  Percentage values $\%$ are always specified as decimal values; for example, $100\% = 1.0 $ and $ 10 \% $ corresponds to $ 0.1 $.
 
 Another important note is, that every \tikzsym command has to be completed with an semicolon ``;''. If this semicolon is not set, the command can not be performed, this leads finally to an error message by the compilation.
 

--- a/stanli.tex
+++ b/stanli.tex
@@ -156,13 +156,13 @@ emphstyle={\color{red}\bfseries},
 	\lineload{2}{a}{b}[1][1][.5];
 	\lineload{2}{b}{c};
 	
-	\dimensioning{1}{a}{b}{-2.5}[$3,0$];
-	\dimensioning{1}{b}{c}{-2.5}[$8,0$];
-	\dimensioning{1}{c}{d}{-2.5}[$8,0$];
-	\dimensioning{1}{d}{e}{-2.5}[$3,0$];
-	\dimensioning{2}{f}{a}{-1}[$1,0$];
-	\dimensioning{2}{g}{f}{-1}[$2,0$];
-	\dimensioning{2}{a}{c}{-1}[$2,0$];
+	\dimensioning{1}{a}{b}{-2.5}[$3.0$];
+	\dimensioning{1}{b}{c}{-2.5}[$8.0$];
+	\dimensioning{1}{c}{d}{-2.5}[$8.0$];
+	\dimensioning{1}{d}{e}{-2.5}[$3.0$];
+	\dimensioning{2}{f}{a}{-1}[$1.0$];
+	\dimensioning{2}{g}{f}{-1}[$2.0$];
+	\dimensioning{2}{a}{c}{-1}[$2.0$];
 	
 	\influenceline{a}{e}{3}[.3];
 	
@@ -218,13 +218,13 @@ emphstyle={\color{red}\bfseries},
 	\lineload{2}{a}{b}[1][1][.5];
 	\lineload{2}{b}{c};
 	
-	\dimensioning{1}{a}{b}{-2.5}[$3,0$];
-	\dimensioning{1}{b}{c}{-2.5}[$8,0$];
-	\dimensioning{1}{c}{d}{-2.5}[$8,0$];
-	\dimensioning{1}{d}{e}{-2.5}[$3,0$];
-	\dimensioning{2}{f}{a}{-1}[$1,0$];
-	\dimensioning{2}{g}{f}{-1}[$2,0$];
-	\dimensioning{2}{a}{c}{-1}[$2,0$];
+	\dimensioning{1}{a}{b}{-2.5}[$3.0$];
+	\dimensioning{1}{b}{c}{-2.5}[$8.0$];
+	\dimensioning{1}{c}{d}{-2.5}[$8.0$];
+	\dimensioning{1}{d}{e}{-2.5}[$3.0$];
+	\dimensioning{2}{f}{a}{-1}[$1.0$];
+	\dimensioning{2}{g}{f}{-1}[$2.0$];
+	\dimensioning{2}{a}{c}{-1}[$2.0$];
 	
 	\influenceline{a}{e}{3}[.3];
 	
@@ -2364,13 +2364,13 @@ In this tutorial, the basic principles of designing with \tikzsym and ``structur
 	\lineload{2}{a}{b}[1][1][.5];
 	\lineload{2}{b}{c};
 	
-	\dimensioning{1}{a}{b}{-2.5}[$3,0$];
-	\dimensioning{1}{b}{c}{-2.5}[$8,0$];
-	\dimensioning{1}{c}{d}{-2.5}[$8,0$];
-	\dimensioning{1}{d}{e}{-2.5}[$3,0$];
-	\dimensioning{2}{f}{a}{-1}[$1,0$];
-	\dimensioning{2}{g}{f}{-1}[$2,0$];
-	\dimensioning{2}{a}{c}{-1}[$2,0$];
+	\dimensioning{1}{a}{b}{-2.5}[$3.0$];
+	\dimensioning{1}{b}{c}{-2.5}[$8.0$];
+	\dimensioning{1}{c}{d}{-2.5}[$8.0$];
+	\dimensioning{1}{d}{e}{-2.5}[$3.0$];
+	\dimensioning{2}{f}{a}{-1}[$1.0$];
+	\dimensioning{2}{g}{f}{-1}[$2.0$];
+	\dimensioning{2}{a}{c}{-1}[$2.0$];
 	
 	\influenceline{a}{e}{3}[.3];
 	
@@ -2669,13 +2669,13 @@ Actually, the roof is already finished and ready for use. However, for the purpo
 
 \end{minipage}
 \begin{minipage}[c]{0.45\linewidth}\begin{lstlisting}
-	\dimensioning{1}{a}{b}{-2.5}[$3,0$];
-	\dimensioning{1}{b}{c}{-2.5}[$8,0$];
-	\dimensioning{1}{c}{d}{-2.5}[$8,0$];
-	\dimensioning{1}{d}{e}{-2.5}[$3,0$];
-	\dimensioning{2}{f}{a}{-1}[$1,0$];
-	\dimensioning{2}{g}{f}{-1}[$2,0$];
-	\dimensioning{2}{a}{c}{-1}[$2,0$];
+	\dimensioning{1}{a}{b}{-2.5}[$3.0$];
+	\dimensioning{1}{b}{c}{-2.5}[$8.0$];
+	\dimensioning{1}{c}{d}{-2.5}[$8.0$];
+	\dimensioning{1}{d}{e}{-2.5}[$3.0$];
+	\dimensioning{2}{f}{a}{-1}[$1.0$];
+	\dimensioning{2}{g}{f}{-1}[$2.0$];
+	\dimensioning{2}{a}{c}{-1}[$2.0$];
 	
 	\influenceline{a}{e}{3}[.3];
 \end{lstlisting}\vspace{-7mm}
@@ -2716,13 +2716,13 @@ Actually, the roof is already finished and ready for use. However, for the purpo
 	\lineload{2}{a}{b}[1][1][.5];
 	\lineload{2}{b}{c};
 	
-	\dimensioning{1}{a}{b}{-2.5}[$3,0$];
-	\dimensioning{1}{b}{c}{-2.5}[$8,0$];
-	\dimensioning{1}{c}{d}{-2.5}[$8,0$];
-	\dimensioning{1}{d}{e}{-2.5}[$3,0$];
-	\dimensioning{2}{f}{a}{-1}[$1,0$];
-	\dimensioning{2}{g}{f}{-1}[$2,0$];
-	\dimensioning{2}{a}{c}{-1}[$2,0$];
+	\dimensioning{1}{a}{b}{-2.5}[$3.0$];
+	\dimensioning{1}{b}{c}{-2.5}[$8.0$];
+	\dimensioning{1}{c}{d}{-2.5}[$8.0$];
+	\dimensioning{1}{d}{e}{-2.5}[$3.0$];
+	\dimensioning{2}{f}{a}{-1}[$1.0$];
+	\dimensioning{2}{g}{f}{-1}[$2.0$];
+	\dimensioning{2}{a}{c}{-1}[$2.0$];
 	
 	\influenceline{a}{e}{3}[.3];
 		
@@ -2782,13 +2782,13 @@ Now the only missing parts are the names of nodes and bars, then roof constructi
 	\lineload{2}{a}{b}[1][1][.5];
 	\lineload{2}{b}{c};
 	
-	\dimensioning{1}{a}{b}{-2.5}[$3,0$];
-	\dimensioning{1}{b}{c}{-2.5}[$8,0$];
-	\dimensioning{1}{c}{d}{-2.5}[$8,0$];
-	\dimensioning{1}{d}{e}{-2.5}[$3,0$];
-	\dimensioning{2}{f}{a}{-1}[$1,0$];
-	\dimensioning{2}{g}{f}{-1}[$2,0$];
-	\dimensioning{2}{a}{c}{-1}[$2,0$];
+	\dimensioning{1}{a}{b}{-2.5}[$3.0$];
+	\dimensioning{1}{b}{c}{-2.5}[$8.0$];
+	\dimensioning{1}{c}{d}{-2.5}[$8.0$];
+	\dimensioning{1}{d}{e}{-2.5}[$3.0$];
+	\dimensioning{2}{f}{a}{-1}[$1.0$];
+	\dimensioning{2}{g}{f}{-1}[$2.0$];
+	\dimensioning{2}{a}{c}{-1}[$2.0$];
 	
 	\influenceline{a}{e}{3}[.3];
 	
@@ -2843,13 +2843,13 @@ Now the guides can be deleted and the scaling factor can be chosen so that the e
 	\lineload{2}{a}{b}[1][1][.5];
 	\lineload{2}{b}{c};
 	
-	\dimensioning{1}{a}{b}{-2.5}[$3,0$];
-	\dimensioning{1}{b}{c}{-2.5}[$8,0$];
-	\dimensioning{1}{c}{d}{-2.5}[$8,0$];
-	\dimensioning{1}{d}{e}{-2.5}[$3,0$];
-	\dimensioning{2}{f}{a}{-1}[$1,0$];
-	\dimensioning{2}{g}{f}{-1}[$2,0$];
-	\dimensioning{2}{a}{c}{-1}[$2,0$];
+	\dimensioning{1}{a}{b}{-2.5}[$3.0$];
+	\dimensioning{1}{b}{c}{-2.5}[$8.0$];
+	\dimensioning{1}{c}{d}{-2.5}[$8.0$];
+	\dimensioning{1}{d}{e}{-2.5}[$3.0$];
+	\dimensioning{2}{f}{a}{-1}[$1.0$];
+	\dimensioning{2}{g}{f}{-1}[$2.0$];
+	\dimensioning{2}{a}{c}{-1}[$2.0$];
 	
 	\influenceline{a}{e}{3}[.3];
 	
@@ -2905,13 +2905,13 @@ Now the guides can be deleted and the scaling factor can be chosen so that the e
 	\lineload{2}{a}{b}[1][1][.5];
 	\lineload{2}{b}{c};
 	
-	\dimensioning{1}{a}{b}{-2.5}[$3,0$];
-	\dimensioning{1}{b}{c}{-2.5}[$8,0$];
-	\dimensioning{1}{c}{d}{-2.5}[$8,0$];
-	\dimensioning{1}{d}{e}{-2.5}[$3,0$];
-	\dimensioning{2}{f}{a}{-1}[$1,0$];
-	\dimensioning{2}{g}{f}{-1}[$2,0$];
-	\dimensioning{2}{a}{c}{-1}[$2,0$];
+	\dimensioning{1}{a}{b}{-2.5}[$3.0$];
+	\dimensioning{1}{b}{c}{-2.5}[$8.0$];
+	\dimensioning{1}{c}{d}{-2.5}[$8.0$];
+	\dimensioning{1}{d}{e}{-2.5}[$3.0$];
+	\dimensioning{2}{f}{a}{-1}[$1.0$];
+	\dimensioning{2}{g}{f}{-1}[$2.0$];
+	\dimensioning{2}{a}{c}{-1}[$2.0$];
 	
 	\influenceline{a}{e}{3}[.3];
 	


### PR DESCRIPTION
Hi,

And hopefully, last today's PR. I have prepared a special branch (really as with the other PRs) and a separated PR for this, as personal preferences may have a point here and some of my changes may be controversial.

This includes two commits

- First one is to make units look more like what is written in section 5.1 of the SI brochure at [https://www.bipm.org/en/publications/si-brochure/](https://www.bipm.org/en/publications/si-brochure/), that is, use roman (upright) regardless of the surrounding text. 
I did not touch one occurrence in the manual in the temperature section. For whatever reason 10°C did not look as well as I expected when written in roman. By the way, I represented the units with normal roman. I usually use \mathrm{} for that, but I thought it made the code too noisy for reading.
- The other commit is about decimal separators. In the documentation some parts or the 3D library use decimal point, but most other parts use comma as decimal separator. In Spain comma is used as decimal separator, as I think is in Germany and France, and in most non English speaking Europe, but since the documents are written in English I think they should use point as decimal separator. Note that if this is accepted, images included from README.rst should be updated accordingly.

No changes in stanli.pdf or example.pdf are included in this commit. They need to be updated separately.

Regards,