### PR TITLE
Use a fake spiral for torsion spring. Add CW variant.

### DIFF
--- a/stanli.sty
+++ b/stanli.sty
@@ -98,6 +98,7 @@
 \newcommand{\supportHeight}{5mm}				%
 \newcommand{\supportHatchingLength}{20mm}	%
 \newcommand{\supportHatchingHeight}{5mm}	%
+\newcommand{\springTorsionRadius}{6mm}      % Maximum radius of torsional spring
 
 \newcommand{\barGap}{1.5mm}							%
 \newcommand{\barAngle}{45}							%
@@ -432,16 +433,56 @@
           \end{scope}
 	}{}
 
-	\ifthenelse{\equal{#1}{6}}{		%
-		\begin{scope}[rotate around={#3:(#2)}]
-			\begin{scope}[rotate around={-90:(#2)},shift={(#2)}]
-				\draw[normalLine,scale=0.035,domain=0:18.85,variable=\t,smooth,]
-				plot({\t*sin(\t r)},{-\t*cos(\t r)});
-			\end{scope}
-			\draw [normalLine] ($(#2)+1*(-\supportBasicLength/2.5,0)$) -- ++(-\supportBasicLength/3.5,0);
-			\clip ($(#2)+1*(-\supportBasicLength/2.5,0)$) rectangle ($(#2)+1*(-\supportBasicLength/1.47,-\supportBasicHeight/2)$);
-			\draw[hatchingspring]($(#2)+1*(0,0)$) -- ++(-\supportHatchingLength/2,0);
-		\end{scope}
+	\ifthenelse{\equal{#1}{6}}{ % Torsion spring
+          \begin{scope}[rotate around={#3:(#2)}]
+            % Will convert \springTorsionRadius to pt before calc
+            % 17.007874pt are 6mm
+            \pgfmathsetmacro{\SpiralScale}{\springTorsionRadius/17.007874}
+            \begin{scope}[scale=\SpiralScale]
+              \draw (#2) [normalLine] % A fake spiral
+                arc [start angle=-180,end angle=0,radius=0.6mm]
+                arc [start angle=0,end angle=180,radius=1.2mm]
+                arc [start angle=-180,end angle=0,radius=2mm]
+                arc [start angle=0,end angle=180,radius=3mm]
+                arc [start angle=-180,end angle=0,radius=4.2mm]
+                arc [start angle=0,end angle=180,radius=5.6mm];
+            \end{scope}
+            \draw [normalLine]
+              ($(#2)+1*(-\springTorsionRadius -\supportBasicLength/6, 0)$)
+              -- ++(\supportBasicLength/3, 0);
+            \clip
+              ($(#2)+1*(-\springTorsionRadius-\supportBasicLength/6,0)$)
+              rectangle ++(\supportBasicLength/3,-\supportBasicHeight/2);
+            \draw[hatchingspring]
+              ($(#2)+1*(0,0)$)
+              -- ++(-\supportHatchingLength/2,0);
+          \end{scope}
+	}{}
+
+	\ifthenelse{\equal{#1}{6cw}}{ % Torsion spring
+          \begin{scope}[rotate around={#3:(#2)}]
+            % Will convert \springTorsionRadius to pt before calc
+            % 17.007874pt are 6mm
+            \pgfmathsetmacro{\SpiralScale}{\springTorsionRadius/17.007874}
+            \begin{scope}[scale=\SpiralScale]
+              \draw (#2) [normalLine] % A fake spiral
+                arc [start angle=0,end angle=-180,radius=0.6mm]
+                arc [start angle=180,end angle=0,radius=1.2mm]
+                arc [start angle=0,end angle=-180,radius=2mm]
+                arc [start angle=180,end angle=0,radius=3mm]
+                arc [start angle=0,end angle=-180,radius=4.2mm]
+                arc [start angle=180,end angle=0,radius=5.6mm];
+            \end{scope}
+            \draw [normalLine]
+              ($(#2)+1*(\springTorsionRadius -\supportBasicLength/6, 0)$)
+              -- ++(\supportBasicLength/3, 0);
+            \clip
+              ($(#2)+1*(\springTorsionRadius-\supportBasicLength/6,0)$)
+              rectangle ++(\supportBasicLength/3,-\supportBasicHeight/2);
+            \draw[hatchingspring]
+              ($(#2)+1*(\springTorsionRadius + \supportHatchingLength/2 -\supportBasicLength/3 ,0)$)
+              -- ++(-\supportHatchingLength/2,0);
+          \end{scope}
 	}{}
 
 }

--- a/stanli.tex
+++ b/stanli.tex
@@ -1194,20 +1194,27 @@ zig-zag line and (\texttt{5c}) a coil.
 \endgroup
 
 \begingroup
-\hspace{7mm}\lstinline[emph={support}]|\support{6}{insertion point}[rotation];|
-
+\begin{lstlisting}[emph={support},backgroundcolor=\color{white},xleftmargin=7mm,belowskip=-0.5cm]
+\support{6}{insertion point}[rotation];
+\support{6cw}{insertion point}[rotation];
+\end{lstlisting}
 \leftskip=14mm Type $6$ describes a torsion spring.
+Type \texttt{6cw} provides a clockwise variant.
 
 \leftskip=14mm\begin{minipage}[c]{0.3\linewidth}
 	\begin{tikzpicture}[framed]
 			\point{a}{0}{0};
+			\point{b}{1.5}{0};
 			\support{6}{a}[-45];
+			\support{6cw}{b}[-45];
 	\end{tikzpicture}
 \end{minipage}
 \begin{minipage}{0.61\linewidth}\begin{lstlisting}
 	\begin{tikzpicture}
 		\point{a}{0}{0};
+		\point{b}{1.5}{0};
 		\support{6}{a}[-45];
+		\support{6cw}{b}[-45];
 	\end{tikzpicture}\end{lstlisting}\vspace{-7mm}
 \end{minipage}
 

--- a/stanli.tex
+++ b/stanli.tex
@@ -1170,9 +1170,8 @@ Two variants are available, (\texttt{4}) with a slider and (\texttt{4ooo}) with 
 \support{5}{insertion point}[rotation];
 \support{5c}{insertion point}[rotation];
 \end{lstlisting}
-\leftskip=14mm Type $5$ describes a spring.
-Two alternative representations are available, (\texttt{5}) will use a
-zig-zag line and (\texttt{5c}) a coil.
+\leftskip=14mm Type $5$ describes a spring (zig-zag variant).
+Type \texttt{5c} provides a coil variant.
 
 \leftskip=14mm\begin{minipage}[c]{0.3\linewidth}
 	\begin{tikzpicture}[framed]


### PR DESCRIPTION
Hi, 

Here goes a PR with a proposal for the last of the stanli things I have been working on, for your consideration. It redefines the torsion spring to use a fake spiral made out of arcs. This looks a bit smoother (using plot, steps were still noticed) and reaches the "ground" perpendicularly. It also has something of my personal taste, it is not linear. Definition uses a new variable \springTorsionRadius to control the size of the spring, which should allow for easier resizing. It is chosen to match the point to "ground" distance in bearings.

This PR also includes a clockwise variant for the torsional spring. 

PR also includes a minor rewording of the stanli.tex support{5*} section, just to have all \hinge{1} stuff stay in the page.

This is how entry in stanli.pdf entry would look with the changes

![image](https://user-images.githubusercontent.com/33841417/33627129-dcd9f584-d9fc-11e7-9301-59b552237f62.png)

Here goes a comparison of current and proposed shapes (red lines do not go into PR).

![image](https://user-images.githubusercontent.com/33841417/33627083-b57987ca-d9fc-11e7-8e43-ba20e9b7ff69.png)

As before, none of the pdf files are rebuilt.

Regards,