### PR TITLE
Minor cosmetic changes in torsion spring.

### DIFF
--- a/stanli.sty
+++ b/stanli.sty
@@ -480,7 +480,7 @@
               ($(#2)+1*(\springTorsionRadius-\supportBasicLength/6,0)$)
               rectangle ++(\supportBasicLength/3,-\supportBasicHeight/2);
             \draw[hatchingspring]
-              ($(#2)+1*(\springTorsionRadius + \supportHatchingLength/2 -\supportBasicLength/3 ,0)$)
+              ($(#2)+1*(2*\springTorsionRadius ,0)$)
               -- ++(-\supportHatchingLength/2,0);
           \end{scope}
 	}{}

--- a/stanli.sty
+++ b/stanli.sty
@@ -448,11 +448,11 @@
                 arc [start angle=0,end angle=180,radius=5.6mm];
             \end{scope}
             \draw [normalLine]
-              ($(#2)+1*(-\springTorsionRadius -\supportBasicLength/6, 0)$)
-              -- ++(\supportBasicLength/3, 0);
+              ($(#2)+1*(-\springTorsionRadius -\supportBasicLength/7, 0)$)
+              -- ++(\supportBasicLength/3.5, 0);
             \clip
-              ($(#2)+1*(-\springTorsionRadius-\supportBasicLength/6,0)$)
-              rectangle ++(\supportBasicLength/3,-\supportBasicHeight/2);
+              ($(#2)+1*(-\springTorsionRadius-\supportBasicLength/7,0)$)
+              rectangle ++(\supportBasicLength/3.5,-\supportBasicHeight/2);
             \draw[hatchingspring]
               ($(#2)+1*(0,0)$)
               -- ++(-\supportHatchingLength/2,0);
@@ -474,11 +474,11 @@
                 arc [start angle=180,end angle=0,radius=5.6mm];
             \end{scope}
             \draw [normalLine]
-              ($(#2)+1*(\springTorsionRadius -\supportBasicLength/6, 0)$)
-              -- ++(\supportBasicLength/3, 0);
+              ($(#2)+1*(\springTorsionRadius -\supportBasicLength/7, 0)$)
+              -- ++(\supportBasicLength/3.5, 0);
             \clip
-              ($(#2)+1*(\springTorsionRadius-\supportBasicLength/6,0)$)
-              rectangle ++(\supportBasicLength/3,-\supportBasicHeight/2);
+              ($(#2)+1*(\springTorsionRadius-\supportBasicLength/7,0)$)
+              rectangle ++(\supportBasicLength/3.5,-\supportBasicHeight/2);
             \draw[hatchingspring]
               ($(#2)+1*(2*\springTorsionRadius ,0)$)
               -- ++(-\supportHatchingLength/2,0);


### PR DESCRIPTION
Hi, Jürgen,

Thanks for all the merging. 

Regarding torsional springs I noticed a minor difference in my hatch size wrt your original size. I was using a size in my tests and finally did not reset it to your original size, so it is slightly larger.  This change should make it use the same size you had before. 

This PR also includes a minor code simplification when setting the origin of the hatch in the clockwise variant of torsional spring.

Sorry for bothering you with this additional PR. Should not have missed this before. 

Regards,