### PR TITLE
Added bendingbeam_line definition to enable scopes #22

### DIFF
--- a/stanli.sty
+++ b/stanli.sty
@@ -152,6 +152,17 @@
 \tikzstyle{tinyLine}=[line width=\tinyLineWidth,]
 
 %------------------------------------------------
+%		beam styles
+%------------------------------------------------
+
+\tikzset{
+	bendingbeam_line/.style args = {#1}{
+	line width=#1,
+	},
+	bendingbeam_line/.default=\hugeLineWidth
+}
+
+%------------------------------------------------
 %		spring styles
 %------------------------------------------------
 
@@ -311,11 +322,19 @@
 %			\beam{type}{initial point}{end point}[rounded initial point][rounded end point]
 
 \newcommandx{\beam}[5][4=0,5=0]{
-	\ifthenelse{\equal{#1}{1}}{		%
-		\draw [hugeLine] (#2) -- (#3);
+	\ifthenelse{\equal{#1}{1}}{		%  bending beam - with characteristic ﬁber
+		\draw [bendingbeam_line] (#2) -- (#3);
 		\coordinate (barVarA) at ($ (#2)!\barGap!-\barAngle:(#3) $);
 		\coordinate (barVarB) at ($ (#3)!\barGap!\barAngle:(#2) $);
 		\draw [smallLine,dashed] (barVarA) -- (barVarB);
+		\ifthenelse{\equal{#4}{0}}{}
+			{\fill (#2) circle (\hugeLineWidth/2);}
+		\ifthenelse{\equal{#5}{0}}{}
+			{\fill (#3) circle (\hugeLineWidth/2);}
+	}{}
+
+	\ifthenelse{\equal{#1}{1ncf}}{		%  bending beam - no characteristic ﬁber
+		\draw [bendingbeam_line] (#2) -- (#3);
 		\ifthenelse{\equal{#4}{0}}{}
 			{\fill (#2) circle (\hugeLineWidth/2);}
 		\ifthenelse{\equal{#5}{0}}{}
@@ -377,80 +396,71 @@
 		\end{scope}
 	}{}
         
-        \ifthenelse{\equal{#1}{2oo}}{ % 2oo: Floating bearing with two rollers
-          \begin{scope}[rotate around={#3:(#2)}]
-            \draw [normalLine] (#2)
-              -- ++(\supportLength/2,-\supportHeight+\supportGap)
-              -- ++(-\supportLength,0)
-              -- cycle;
-            \draw[normalLine, fill=white]
-              ($(#2)+(\supportBasicLength/5,-\supportHeight)$)
-              circle (0.9*\supportGap);
-            \draw[normalLine, fill=white]
-              ($(#2)+(-\supportBasicLength/5,-\supportHeight)$)
-              circle (0.9*\supportGap);
-            \draw [normalLine]
-              ($(#2)+1*(\supportBasicLength/2,-\supportHeight-\supportGap)$)
-              -- ++(-\supportBasicLength,0);
-            \clip
-              ($(#2)+1*(-\supportBasicLength/2,-\supportBasicHeight-\supportHeight-\supportGap)$)
-              rectangle ($(#2)+1*(\supportBasicLength/2,-\supportHeight-\supportGap)$);
-            \draw[hatching]
-              ($(#2)+1*(\supportHatchingLength/2,-\supportHatchingHeight-\supportGap)$)
-              -- ++(-\supportHatchingLength,0);
-          \end{scope}
-        }{}
+	\ifthenelse{\equal{#1}{2oo}}{ % 2oo: Floating bearing with two rollers (Note: letter "o" not zero "0")
+		\begin{scope}[rotate around={#3:(#2)}]
+			\draw [normalLine] (#2)
+				-- ++(\supportLength/2,-\supportHeight+\supportGap)
+				-- ++(-\supportLength,0)
+				-- cycle;
+			\draw[normalLine, fill=white]
+			 	($(#2)+(\supportBasicLength/5,-\supportHeight)$)
+			 	circle (0.9*\supportGap);
+			 \draw[normalLine, fill=white]
+			 	($(#2)+(-\supportBasicLength/5,-\supportHeight)$)
+			 	circle (0.9*\supportGap);
+			 \draw [normalLine]
+			 	($(#2)+1*(\supportBasicLength/2,-\supportHeight-\supportGap)$)
+			 	-- ++(-\supportBasicLength,0);
+			 \clip
+			 	($(#2)+1*(-\supportBasicLength/2,-\supportBasicHeight-\supportHeight-\supportGap)$)
+			 	rectangle ($(#2)+1*(\supportBasicLength/2,-\supportHeight-\supportGap)$);
+			 \draw[hatching]
+			 	($(#2)+1*(\supportHatchingLength/2,-\supportHatchingHeight-\supportGap)$)
+			 	-- ++(-\supportHatchingLength,0);
+		\end{scope}
+	}{}
 
-        \ifthenelse{\equal{#1}{2oowh}}{ % 2oowh: Floating bearing with two rollers MOD: without hatching
-          	\begin{scope}[rotate around={#3:(#2)}]
-            \draw [normalLine] (#2)
-              -- ++(\supportLength/2,-\supportHeight+\supportGap)
-              -- ++(-\supportLength,0)
-              -- cycle;
-            \draw[normalLine, fill=white]
-              ($(#2)+(\supportBasicLength/5,-\supportHeight)$)
-              circle (0.9*\supportGap);
-            \draw[normalLine, fill=white]
-              ($(#2)+(-\supportBasicLength/5,-\supportHeight)$)
-              circle (0.9*\supportGap);
-     %       \draw [normalLine]
-      %       ($(#2)+1*(\supportBasicLength/2,-\supportHeight-\supportGap)$)
-      %        -- ++(-\supportBasicLength,0);
-       %     \clip
-     %         ($(#2)+1*(-\supportBasicLength/2,-\supportBasicHeight-\supportHeight-\supportGap)$)
-      %        rectangle ($(#2)+1*(\supportBasicLength/2,-\supportHeight-\supportGap)$);
-        %   \draw[hatching]
-        %      ($(#2)+1*(\supportHatchingLength/2,-\supportHatchingHeight-\supportGap)$)
-         %     -- ++(-\supportHatchingLength,0);
-          \end{scope}
-        }{}
+	\ifthenelse{\equal{#1}{2oowh}}{ % 2oowh: Floating bearing with two rollers MOD: without hatching (Note: letter "o" not zero "0")
+		\begin{scope}[rotate around={#3:(#2)}]
+		\draw [normalLine] (#2)
+			-- ++(\supportLength/2,-\supportHeight+\supportGap)
+			-- ++(-\supportLength,0)
+			-- cycle;
+		\draw[normalLine, fill=white]
+			($(#2)+(\supportBasicLength/5,-\supportHeight)$)
+			circle (0.9*\supportGap);
+		\draw[normalLine, fill=white]
+			($(#2)+(-\supportBasicLength/5,-\supportHeight)$)
+			circle (0.9*\supportGap);
+		\end{scope}
+	}{}
 
-        \ifthenelse{\equal{#1}{2ooo}}{ % 2ooo: Floating bearing with three rollers
-          \begin{scope}[rotate around={#3:(#2)}]
-            \draw [normalLine] (#2)
-              -- ++(\supportLength/2,-\supportHeight+\supportGap)
-              -- ++(-\supportLength,0)
-              -- cycle;
-            \draw[normalLine, fill=white]
-              ($(#2)+(\supportBasicLength/4,-\supportHeight)$)
-              circle (0.9*\supportGap);
-            \draw[normalLine, fill=white]
-              ($(#2)+(0.0,-\supportHeight)$)
-              circle (0.9*\supportGap);
-            \draw[normalLine, fill=white]
-              ($(#2)+(-\supportBasicLength/4,-\supportHeight)$)
-              circle (0.9*\supportGap);
-            \draw [normalLine]
-              ($(#2)+1*(\supportBasicLength/2,-\supportHeight-\supportGap)$)
-              -- ++(-\supportBasicLength,0);
-            \clip
-              ($(#2)+1*(-\supportBasicLength/2,-\supportBasicHeight-\supportHeight-\supportGap)$)
-              rectangle ($(#2)+1*(\supportBasicLength/2,-\supportHeight-\supportGap)$);
-            \draw[hatching]
-              ($(#2)+1*(\supportHatchingLength/2,-\supportHatchingHeight-\supportGap)$)
-              -- ++(-\supportHatchingLength,0);
-          \end{scope}
-        }{}
+	\ifthenelse{\equal{#1}{2ooo}}{ % 2ooo: Floating bearing with three rollers (Note: letter "o" not zero "0")
+	 	\begin{scope}[rotate around={#3:(#2)}]
+			\draw [normalLine] (#2)
+				-- ++(\supportLength/2,-\supportHeight+\supportGap)
+				-- ++(-\supportLength,0)
+				-- cycle;
+			\draw[normalLine, fill=white]
+				($(#2)+(\supportBasicLength/4,-\supportHeight)$)
+				circle (0.9*\supportGap);
+			\draw[normalLine, fill=white]
+				($(#2)+(0.0,-\supportHeight)$)
+				circle (0.9*\supportGap);
+			\draw[normalLine, fill=white]
+				($(#2)+(-\supportBasicLength/4,-\supportHeight)$)
+				circle (0.9*\supportGap);
+			\draw [normalLine]
+				($(#2)+1*(\supportBasicLength/2,-\supportHeight-\supportGap)$)
+				-- ++(-\supportBasicLength,0);
+			\clip
+				($(#2)+1*(-\supportBasicLength/2,-\supportBasicHeight-\supportHeight-\supportGap)$)
+				rectangle ($(#2)+1*(\supportBasicLength/2,-\supportHeight-\supportGap)$);
+			\draw[hatching]
+				($(#2)+1*(\supportHatchingLength/2,-\supportHatchingHeight-\supportGap)$)
+				-- ++(-\supportHatchingLength,0);
+		\end{scope}
+	}{}
 
 	\ifthenelse{\equal{#1}{3}}{		%
 		\begin{scope}[rotate around={#3:(#2)}]


### PR DESCRIPTION
- Also added line style with no characteristic fibre `1ncf` - this change would require updating the manual to reflect.
- Removed commented-out lines
- Added comment `(Note: letter "o" not zero "0")` for supports
