### PR TITLE
stanli.tex: Drop obsolete scrpage2.sty in favour of scrlayer-scrpage,sty

### DIFF
--- a/stanli.tex
+++ b/stanli.tex
@@ -23,7 +23,7 @@
 \usepackage[english]{babel}
 \usepackage[latin1]{inputenc}
 \usepackage{ae,aecompl}
-\usepackage[automark]{scrpage2}
+\usepackage[automark]{scrlayer-scrpage}
 \usepackage[pdftex]{graphicx}
 \usepackage[margin=0.75in]{geometry}
 \usepackage{xcolor}


### PR DESCRIPTION
Hi, Jürgen,

Upstream author has declared the package scrpage2 obsolete. It is no
longer included in TeX live and MikTeX. Users are advised to switch
to the successor package scrlayer-scrpage.

See https://sourceforge.net/p/koma-script/wiki-en/Error_scrpage2/
    https://tex.stackexchange.com/questions/541766/latex-error-file-scrpage2-sty-not-found

This commit changes stanli.tex to deal with this. Please consider it.

Regards,