### PR TITLE
stanli.sty: Validate type option passed to 2D and 3D library elements.

### DIFF
--- a/stanli.sty
+++ b/stanli.sty
@@ -41,6 +41,13 @@
 % 2D Structural Analysis Library base on TikZ
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+%================================================
+%               some conditionals
+% ================================================
+
+% Conditional to check validity of command type option
+\newif\ifSTNL@ValidCommandTypeOption
+
 %
 %================================================
 %		some variables
@@ -322,6 +329,7 @@
 %			\beam{type}{initial point}{end point}[rounded initial point][rounded end point]
 
 \newcommandx{\beam}[5][4=0,5=0]{
+  \global\STNL@ValidCommandTypeOptionfalse
 	\ifthenelse{\equal{#1}{1}}{		%  bending beam - with characteristic ﬁber
 		\draw [bendingbeam_line] (#2) -- (#3);
 		\coordinate (barVarA) at ($ (#2)!\barGap!-\barAngle:(#3) $);
@@ -331,6 +339,7 @@
 			{\fill (#2) circle (\hugeLineWidth/2);}
 		\ifthenelse{\equal{#5}{0}}{}
 			{\fill (#3) circle (\hugeLineWidth/2);}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
 	\ifthenelse{\equal{#1}{2}}{		% Truss rod
@@ -339,10 +348,12 @@
 			{\fill (#2) circle (\bigLineWidth/2);}
 		\ifthenelse{\equal{#5}{0}}{}
 			{\fill (#3) circle (\bigLineWidth/2);}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{3}}{		% Invisible (dashed) member
 		\draw [normalLine,dashed] (#2) -- (#3);
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{4}}{		%  bending beam - no characteristic ﬁber
@@ -351,7 +362,9 @@
 			{\fill (#2) circle (\hugeLineWidth/2);}
 		\ifthenelse{\equal{#5}{0}}{}
 			{\fill (#3) circle (\hugeLineWidth/2);}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
+        \ifthenelse{\boolean{STNL@ValidCommandTypeOption}}{}{\errmessage{stanli::beam: Bad type: #1}\errorstopmode}
 }
 
 %------------------------------------------------
@@ -361,6 +374,7 @@
 %
 
 \newcommandx{\support}[3][3=0]{
+  \global\STNL@ValidCommandTypeOptionfalse
 	\ifthenelse{\equal{#1}{1}}{		%
 		\begin{scope}[rotate around={#3:(#2)}]
                         \draw [normalLine] (#2)
@@ -375,6 +389,7 @@
                           ($(#2)+1*(\supportHatchingLength/2,-\supportHatchingHeight-\supportGap)$)
                           -- ++(-\supportHatchingLength,0);
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
         % 2*: Floating bearings.
@@ -386,6 +401,7 @@
 			\clip ($(#2)+1*(-\supportBasicLength/2,-\supportBasicHeight-\supportHeight-\supportGap)$) rectangle ($(#2)+1*(\supportBasicLength/2,-\supportHeight-\supportGap)$);
 			\draw[hatching]($(#2)+1*(\supportHatchingLength/2,-\supportHatchingHeight-\supportGap)$) -- ++(-\supportHatchingLength,0);
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
         
 	\ifthenelse{\equal{#1}{2oo}}{ % 2oo: Floating bearing with two rollers (Note: letter "o" not zero "0")
@@ -410,6 +426,7 @@
 			 	($(#2)+1*(\supportHatchingLength/2,-\supportHatchingHeight-\supportGap)$)
 			 	-- ++(-\supportHatchingLength,0);
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
 	\ifthenelse{\equal{#1}{2oowh}}{ % 2oowh: Floating bearing with two rollers MOD: without hatching (Note: letter "o" not zero "0")
@@ -425,6 +442,7 @@
 			($(#2)+(-\supportBasicLength/5,-\supportHeight)$)
 			circle (0.9*\supportGap);
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
 	\ifthenelse{\equal{#1}{2ooo}}{ % 2ooo: Floating bearing with three rollers (Note: letter "o" not zero "0")
@@ -452,6 +470,7 @@
 				($(#2)+1*(\supportHatchingLength/2,-\supportHatchingHeight-\supportGap)$)
 				-- ++(-\supportHatchingLength,0);
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
 	\ifthenelse{\equal{#1}{3}}{		%
@@ -460,6 +479,7 @@
 			\clip ($(#2)+1*(-\supportBasicLength/2,-\supportBasicHeight)$) rectangle ($(#2)+1*(\supportBasicLength/2,0)$);
 			\draw[hatching]($(#2)+1*(\supportHatchingLength/2,0)$) -- ++(-\supportHatchingLength,0);
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
         % 4*: Fixed supports
@@ -470,6 +490,7 @@
 			\clip ($(#2)+1*(-\supportBasicLength/2,-\supportBasicHeight-\supportGap)$) rectangle ($(#2)+1*(\supportBasicLength/2,-\supportGap)$);
 			\draw[hatching]($(#2)+1*(\supportHatchingLength/2,-\supportGap)$) -- ++(-\supportHatchingLength,0);
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{4ooo}}{  % 4: Fixed support with three rollers
@@ -489,6 +510,7 @@
 			\draw[hatching]($(#2)+1*(\supportHatchingLength/2,-\supportGap*2)$) -- ++(-\supportHatchingLength,0)
 			;
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{5}}{ % Linear spring with zig-zag
@@ -498,6 +520,7 @@
 			\clip ($(#2)+1*(-\supportBasicLength/2,-\supportBasicHeight-\springLength)$) rectangle ($(#2)+1*(\supportBasicLength/2,-\springLength)$);
 			\draw[hatching]($(#2)+1*(\supportHatchingLength/2,-\springLength)$) -- ++(-\supportHatchingLength,0);
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{5c}}{ % Linear spring with coil
@@ -514,6 +537,7 @@
               ($(#2)+1*(\supportHatchingLength/2,-\springLength)$)
               -- ++(-\supportHatchingLength,0);
           \end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
 	\ifthenelse{\equal{#1}{6}}{ % Torsion spring
@@ -540,6 +564,7 @@
               ($(#2)+1*(0,0)$)
               -- ++(-\supportHatchingLength/2,0);
           \end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
 	\ifthenelse{\equal{#1}{6cw}}{ % Torsion spring
@@ -566,8 +591,9 @@
               ($(#2)+1*(2*\springTorsionRadius ,0)$)
               -- ++(-\supportHatchingLength/2,0);
           \end{scope}
+          \global\STNL@ValidCommandTypeOptiontrue
 	}{}
-
+        \ifthenelse{\boolean{STNL@ValidCommandTypeOption}}{}{\errmessage{stanli::support: Bad type: #1}\errorstopmode}
 }
 
 %------------------------------------------------
@@ -578,11 +604,13 @@
 %
 
 \newcommandx{\hinge}[5][3=0,4=0,5=0]{
+  \global\STNL@ValidCommandTypeOptionfalse
 	\ifthenelse{\equal{#1}{1}}{		%
 		\begin{scope}[rotate around={#3:(#2)}]
 			\fill [white] (#2) circle (\hingeRadius);
 			\draw [normalLine] (#2) circle (\hingeRadius);
 		\end{scope} 
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{2}}{		%
@@ -596,6 +624,7 @@
 			\filldraw [fill=white,normalLine] (#2) circle (\hingeRadius);
 		\end{scope}
 		\draw[hugeLine] ($(#2)!\hingeRadius!(#3)$)--(#2)--($(#2)!\hingeRadius!(#4)$);
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{3}}{		%
@@ -604,6 +633,7 @@
 			\draw [normalLine] ($(#2)+1*(\supportGap/2,\supportBasicLength/2)$) -- ++(0,-\supportBasicLength);
 			\draw [normalLine] ($(#2)+1*(-\supportGap/2,\supportBasicLength/2)$) -- ++(0,-\supportBasicLength);
 		\end{scope}	 
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
 	\ifthenelse{\equal{#1}{3ooo}}{		%
@@ -617,6 +647,7 @@
 			\fill [white] ($(#2)+1*(0,-\supportBasicLength*0.35)$)  circle (\hingeRadius*0.5);
 			\draw [normalLine] ($(#2)+1*(0,-\supportBasicLength*0.35)$)  circle (\hingeRadius*0.5);
 		\end{scope}	 
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}		
 	
 	\ifthenelse{\equal{#1}{4}}{		%
@@ -627,6 +658,7 @@
 						-- ++(0,-\hingeAxialHeight) 
 						-- ++(\hingeAxialLength,0);
 		\end{scope}	 
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}	
 
 	\ifthenelse{\equal{#1}{5}}{		%
@@ -634,7 +666,9 @@
 		\coordinate (hingeVarB) at ($ (#2)!\hingeCornerLength!(#4) $);
 		\fill[black] (#2) -- (hingeVarA) -- (hingeVarB) -- cycle;
 		\fill[black] (#2)circle (\hugeLineWidth/2);
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
+        \ifthenelse{\boolean{STNL@ValidCommandTypeOption}}{}{\errmessage{stanli::hinge: Bad type: #1}\errorstopmode}
 }
 
 %------------------------------------------------
@@ -645,6 +679,7 @@
 %
 
 \newcommandx{\load}[5][3=0,4=0,5=0]{
+  \global\STNL@ValidCommandTypeOptionfalse
 	\ifthenelse{\equal{#1}{1}}{		%
 		\ifthenelse{\equal{#5}{0}}
 			{\renewcommand{\helpVarA}{\forceDistance}}
@@ -653,6 +688,7 @@
 			{\renewcommand{\helpVarB}{\forceLength}}
 			{\renewcommand{\helpVarB}{#4}}
 		\draw[force,<-] ($(#2)+1*(#3:\helpVarA)$) --++($(#3:\helpVarB)$);
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
 	\ifthenelse{\equal{#1}{2}}{		%
@@ -665,6 +701,7 @@
 		\begin{scope}[rotate around={#3:(#2)}]
 			\draw[<-,normalLine] ($(#2)+1*(\helpVarA,0)$) arc (0:\helpVarB:\helpVarA);
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
 	\ifthenelse{\equal{#1}{3}}{		%
@@ -677,8 +714,10 @@
 		\begin{scope}[rotate around={#3:(#2)}]
 			\draw[->,normalLine] ($(#2)+1*(\helpVarA,0)$) arc (0:\helpVarB:\helpVarA);
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
-	
+
+        \ifthenelse{\boolean{STNL@ValidCommandTypeOption}}{}{\errmessage{stanli::load: Bad type: #1}\errorstopmode}	
 }
 
 %------------------------------------------------
@@ -698,6 +737,7 @@
 %				[force interval][force length] are optional
 
 \newcommandx{\lineload}[7][4=1,5=1,6=\lineloadInterval,7=\lineloadInterval]{
+  \global\STNL@ValidCommandTypeOptionfalse
 	\ifthenelse{\equal{#1}{1}}{		%
 		\coordinate (lineloadVarA1) at ($ (#2)!\lineloadDistance!90:(#3) $);
 		\coordinate (lineloadVarB1) at ($ (#3)!\lineloadDistance!-90:(#2) $);
@@ -720,6 +760,7 @@
 			\pgfmathsetmacro{\lineloadIntervalEnd}{1-#6/\scalingParameter}
 		\foreach \i in {\lineloadIntervalBegin,\lineloadIntervalStep,...,\lineloadIntervalEnd}
 		\draw [force,->] ($(lineloadVarA2)!\i!(lineloadVarB2)$)-- ($(lineloadVarA1)!\i!(lineloadVarB1)$);
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{2}}{		%
@@ -744,6 +785,7 @@
 			\pgfmathsetmacro{\lineloadIntervalEnd}{1-#6}
 		\foreach \i in {\lineloadIntervalBegin,\lineloadIntervalStep,...,\lineloadIntervalEnd}
 		\draw [force,->] ($(lineloadVarA2)!\i!(lineloadVarB2)$)-- ($(lineloadVarA1)!\i!(lineloadVarB1)$);
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
 	\ifthenelse{\equal{#1}{3}}{		%
@@ -778,6 +820,7 @@
 			\pgfmathsetmacro{\lineloadIntervalEnd}{1-#7}
 		\foreach \i in {\lineloadIntervalBegin,\lineloadIntervalStep,...,\lineloadIntervalEnd}
 		\draw [force,->] ($(lineloadVarA2)!\i!(lineloadVarB2)$)-- ($(lineloadVarA1)!\i!(lineloadVarB1)$);
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{4}}{		%
@@ -793,8 +836,10 @@
 			{\pgfmathsetmacro{\lineloadForceLength}{#5}}
 		\foreach \i in {0,\lineloadIntervalStep,...,\lineloadIntervalEnd}
 		\draw [force,->] ($(lineloadVarA1)!\i!(lineloadVarB1)$) -- ($(lineloadVarA1)!\i+\lineloadForceLength!(lineloadVarB1)$);
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
+        \ifthenelse{\boolean{STNL@ValidCommandTypeOption}}{}{\errmessage{stanli::lineload: Bad type: #1}\errorstopmode}
 }
 
 %------------------------------------------------
@@ -804,6 +849,7 @@
 %
 
 \newcommandx{\dimensioning}[5][5]{
+  \global\STNL@ValidCommandTypeOptionfalse
 	\ifthenelse{\equal{#1}{1}}{		%
 		\path
 			let
@@ -817,6 +863,7 @@
 											(dimensioningVarB)--++(0,\dimensioningBar/2)--++(0,-\dimensioningBar)
 											(dimensioningVarB)--++(\dimensioningBar/4,\dimensioningBar/4)--++(-\dimensioningBar/2,-\dimensioningBar/2)
 											(dimensioningVarA)--(dimensioningVarB) node [sloped,midway,above] {#5};
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
 	\ifthenelse{\equal{#1}{2}}{		%
@@ -832,6 +879,7 @@
 											(dimensioningVarB)--++(\dimensioningBar/2,0)--++(-\dimensioningBar,0)
 											(dimensioningVarB)--++(\dimensioningBar/4,\dimensioningBar/4)--++(-\dimensioningBar/2,-\dimensioningBar/2)
 											(dimensioningVarA)--(dimensioningVarB) node [sloped,midway,above] {#5};
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{3}}{		%
@@ -839,7 +887,9 @@
 		\coordinate (dimensioningVarB) at ($ (#3)!{#4cm}!-90:(#2) $);
 		\draw [smallLine] ($ (dimensioningVarA)!{-\dimensioningBar/3}!90:(dimensioningVarB) $) -- ($ (dimensioningVarA)!{\dimensioningBar/3}!90:(dimensioningVarB) $);
 		\draw [smallLine,<-] (dimensioningVarB) -- (dimensioningVarA)node [sloped,midway,above] {#5};
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
+        \ifthenelse{\boolean{STNL@ValidCommandTypeOption}}{}{\errmessage{stanli::dimensioning: Bad type: #1}\errorstopmode}
 }
 
 %------------------------------------------------
@@ -928,12 +978,14 @@
 %
 
 \newcommandx{\addon}[5][5=1]{
+  \global\STNL@ValidCommandTypeOptionfalse
 	\ifthenelse{\equal{#1}{1}}{		% \addon{type}{insertion point}{end point}{position}
 		\coordinate (addonVarA1) at ($ (#2)!#4!(#3) $);
 		\coordinate (addonVarB1) at ($ (addonVarA1)!\dimensioningBar/2!45:(#3) $);
 		\coordinate (addonVarB2) at ($ (addonVarA1)!\dimensioningBar/2!225:(#3) $);
 		\draw[smallLine] (addonVarB1)--(addonVarB2)
 		($(addonVarB1)+1*(\supportGap,0)$)--($(addonVarB2)+1*(\supportGap,0)$);
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{2}}{		% \addon{type}{insertion point}{initial point}{end point}[position-1/+1]
@@ -950,6 +1002,7 @@
 		}
 		\draw[smallLine] (addonVarA1)--(addonVarC1)-- (addonVarB1);
 		\filldraw (addonVarD1) circle (\smallLineWidth);
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{3}}{		% \addon{type}{insertion point}{initial point}{end point}[position-1/+1]
@@ -963,8 +1016,10 @@
 			\draw [smallLine] (#2) circle (\dimensioningBar)
 												(#2) circle (\dimensioningBar-\normalLineWidth-\normalLineWidth);
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
+        \ifthenelse{\boolean{STNL@ValidCommandTypeOption}}{}{\errmessage{stanli::addon: Bad type: #1}\errorstopmode}
 }
 
 %------------------------------------------------
@@ -975,10 +1030,12 @@
 %
 
 \newcommandx{\notation}[7][4=above right,5=.5,6=above,7=sloped]{
+  \global\STNL@ValidCommandTypeOptionfalse
 	\ifthenelse{\equal{#1}{1}}{		% \notation{1}{insertion point}{labelling}[orientation];
 		\begin{scope}
 			\draw (#2) node [#4]{#3};
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{2}}{		% \notation{2}{insertion point}{labelling}[orientation];
@@ -986,6 +1043,7 @@
 		\draw (#2) node [#4]{#3};
 		\draw[bigLine] (#2)--++(0,\dimensioningBar/2)--++(0,-\dimensioningBar);
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{3}}{		%
@@ -994,6 +1052,7 @@
 		\coordinate (notationVarB2) at ($ (notationVarA1)!\dimensioningBar/2!-90:(#3) $);
 		\draw[bigLine] (notationVarB1)--(notationVarB2);
 		\draw (notationVarA1) node [#6]{#4};
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 		
 	\ifthenelse{\equal{#1}{4}}{		%
@@ -1003,6 +1062,7 @@
 		\begin{scope}
 		\path (#2) -- (#3) node[inner sep=0mm,rectangle,smallLine,fill=white,draw,minimum size=2.5*\hingeRadius,midway,#6,\helpVarB,pos=#5] {#4};
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}	
 	
 	\ifthenelse{\equal{#1}{5}}{		%
@@ -1012,14 +1072,17 @@
 		\begin{scope}
 		\path (#2) -- (#3) node[midway,#6,\helpVarB,pos=#5] {#4};
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
 	\ifthenelse{\equal{#1}{6}}{		%
 		\begin{scope}
 		\draw (#2) node [inner sep=0mm,circle,smallLine,fill=white,draw,minimum size=2.5*\hingeRadius]{#3};
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
+        \ifthenelse{\boolean{STNL@ValidCommandTypeOption}}{}{\errmessage{stanli::notation: Bad type: #1}\errorstopmode}
 }
 
 
@@ -1228,6 +1291,7 @@
 %						Change the xyz-orientation from \daxis{4}  
 
 \newcommandx{\setaxis}[7][2,3,4,5,6,7]{
+  \global\STNL@ValidCommandTypeOptionfalse
 	\ifthenelse{\equal{#1}{1}}{
 		\renewcommand{\DxVarA}{$x$}
 		\renewcommand{\DyVarA}{$y$}
@@ -1235,6 +1299,7 @@
 		\renewcommand{\DxVarB}{$x^\prime$}
 		\renewcommand{\DyVarB}{$y^\prime$}
 		\renewcommand{\DzVarB}{$z^\prime$}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{2}}{
@@ -1244,6 +1309,7 @@
 		\renewcommand{\DxVarB}{$x$}
 		\renewcommand{\DyVarB}{$y$}
 		\renewcommand{\DzVarB}{$z$}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{3}}{
@@ -1253,13 +1319,16 @@
 		\renewcommand{\DxVarB}{#5}
 		\renewcommand{\DyVarB}{#6}
 		\renewcommand{\DzVarB}{#7}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{4}}{
 		\renewcommand{\DxNodePos}{#2}
 		\renewcommand{\DyNodePos}{#3}
 		\renewcommand{\DzNodePos}{#4}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
+        \ifthenelse{\boolean{STNL@ValidCommandTypeOption}}{}{\errmessage{stanli::setaxis: Bad type: #1}\errorstopmode}
 }
 
 %------------------------------------------------
@@ -1297,8 +1366,10 @@
 %						scaling the addons
 
 \newcommandx{\dscaling}[2]{
+  \global\STNL@ValidCommandTypeOptionfalse
 	\ifthenelse{\equal{#1}{1}}{
 		\renewcommand{\DscalingParameter}{#2}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{2}}{
@@ -1331,6 +1402,7 @@
 		%
 		\renewcommand{\DsupportGap}{\DsupportGapPTtoMM*#2mm}
 		\renewcommand{\DsupportLength}{\DsupportLengthPT*#2}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{3}}{
@@ -1341,6 +1413,7 @@
 		\renewcommand{\DaxisLength}{\DaxisLengthPT*#2}
 		\renewcommand{\DlocalaxisLength}{\DlocalaxisLengthPT*#2}
 		\renewcommand{\DaxisDistance}{\DaxisDistancePT*#2}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{4}}{
@@ -1357,19 +1430,23 @@
 		\renewcommand{\DlineloadForce}{\DlineloadForcePT*#2}
 		\renewcommand{\DlineloadInterval}{\DlineloadIntervalPT*#2}
 		\renewcommand{\DlineloadDistanceMM}{\DlineloadDistanceMMPTtoMM*#2mm}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
 	\ifthenelse{\equal{#1}{5}}{
 		\pgfmathsetmacro{\DdimensioningBarPTtoMM}{\DdimensioningBar/2.83527}
 		%
 		\renewcommand{\DdimensioningBar}{\DdimensioningBarPTtoMM*#2mm}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
 	\ifthenelse{\equal{#1}{6}}{
 		\pgfmathsetmacro{\DaddonLengthPTtoMM}{\DaddonLength/2.83527}
 		%
 		\renewcommand{\DaddonLength}{\DaddonLengthPTtoMM*#2mm}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
+        \ifthenelse{\boolean{STNL@ValidCommandTypeOption}}{}{\errmessage{stanli::dscaling: Bad type: #1}\errorstopmode}
 }
 
 %------------------------------------------------
@@ -1406,6 +1483,7 @@
 %						to change the xyz-orientation use \setaxis{4}[x-orientation][y-orientation][z-orientation];
 
 \newcommandx{\daxis}[9][3,4,5=.5,6=right,7=below,8=left,9=0]{
+  \global\STNL@ValidCommandTypeOptionfalse
 	\ifthenelse{\equal{#1}{1}}{		%
 		\ifthenelse{\equal{#3}{}}
 			{\renewcommand{\DhelpVarA}{below}}
@@ -1419,6 +1497,7 @@
 		\draw[axisarrow,->] (#2) --++ (\DaxisLength,0,0)node[\DhelpVarA] {\DxVarA};
 		\draw[axisarrow,->] (#2) --++ (0,\DaxisLength,0)node[\DhelpVarB] {\DyVarA};
 		\draw[axisarrow,->] (#2) --++ (0,0,\DaxisLength)node[\DhelpVarC] {\DzVarA};
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
 	\ifthenelse{\equal{#1}{2}}{		%
@@ -1478,6 +1557,7 @@
 			{\draw[thin,->] (axisVarA2) --++ (\DlocalaxisLength,0,0)node[#8] {\DhelpVarB};}{}
 		\ifthenelse{\equal{#2}{zy}}
 			{\draw[thin,->] (axisVarA2) --++ (-\DlocalaxisLength,0,0)node[#8] {\DhelpVarB};}{}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{3}}{
@@ -1502,7 +1582,9 @@
 		\draw[thin,xtdplot_rotated_coords,->] (0,0,0) -- (.5,0,0) node[\DxNodePos]{\DxVarB};
 		\draw[thin,xtdplot_rotated_coords,->] (0,0,0) -- (0,.5,0) node[\DyNodePos]{\DyVarB};
 		\draw[thin,xtdplot_rotated_coords,->] (0,0,0) -- (0,0,.5) node[\DzNodePos]{\DzVarB};
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
+        \ifthenelse{\boolean{STNL@ValidCommandTypeOption}}{}{\errmessage{stanli::daxis: Bad type: #1}\errorstopmode}
 }
 
 %------------------------------------------------
@@ -1512,12 +1594,14 @@
 %						with rounded initial point or/and rounded end point: 1 or nothing = true, 0=false,
 
 \newcommandx{\dbeam}[5][4=1,5=1]{
+  \global\STNL@ValidCommandTypeOptionfalse
 	\ifthenelse{\equal{#1}{1}}{		%
 		\draw [hugeLine] (#2) -- (#3);
 		\ifthenelse{\equal{#4}{0}}{}
 			{\fill (#2) circle (\DhugeLineWidth/2);}
 		\ifthenelse{\equal{#5}{0}}{}
 			{\fill (#3) circle (\DhugeLineWidth/2);}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{2}}{		%
@@ -1526,11 +1610,14 @@
 			{\fill (#2) circle (\DbigLineWidth/2);}
 		\ifthenelse{\equal{#5}{0}}{}
 			{\fill (#3) circle (\DbigLineWidth/2);}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{3}}{		%
 		\draw [normalLine,dashed] (#2) -- (#3);
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
+        \ifthenelse{\boolean{STNL@ValidCommandTypeOption}}{}{\errmessage{stanli::dbeam: Bad type: #1}\errorstopmode}
 }
 
 %------------------------------------------------
@@ -1556,6 +1643,7 @@
 %						same as type 3 but with springs
 
 \newcommandx{\dsupport}[6][3=1,4=1,5=1,6=1]{
+  \global\STNL@ValidCommandTypeOptionfalse
 	\ifthenelse{\equal{#1}{1}}{		%
 		\ifthenelse{\equal{#3}{0}}{}{
 			\draw [normalLine] (#2)-- ++(-\DsupportLength*#3,0,0);
@@ -1569,6 +1657,7 @@
 			\draw [normalLine] (#2)-- ++(0,0,-\DsupportLength*#5);
 			\filldraw [normalLine,fill=white] ($(#2)+1*(0,0,-\DsupportLength*#5)$) circle (\DhingeRadius);
 		}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 		
 	\ifthenelse{\equal{#1}{2}}{		%
@@ -1589,6 +1678,7 @@
 				\draw [hugeLine] (#2)-- ++(-\DsupportLength/2,0)--++(\DsupportLength,0);
 				\draw [hugeLine] (#2)-- ++(0,-\DsupportLength/2)--++(0,\DsupportLength);
 			\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{3}}{		%
@@ -1605,6 +1695,7 @@
 			\draw [normalLine] ($(#2)+1*(0,0,-\DhingeAxialHeight/2.5)$)-- ++(0,0,-\DsupportLength*#5+\DhingeAxialHeight/2);
 			\filldraw [normalLine,fill=white] ($(#2)+1*(0,0,-\DsupportLength*#5)$) circle (\DhingeRadius);
 		}
+                \global\STNL@ValidCommandTypeOptiontrue
 		
 	}{}	
 		
@@ -1621,6 +1712,7 @@
 			\draw [Dspring] (#2)-- ++(0,0,-\DsupportLength*#5);
 			\filldraw [normalLine,fill=white] ($(#2)+1*(0,0,-\DsupportLength*#5)$) circle (\DhingeRadius);
 		}
+                \global\STNL@ValidCommandTypeOptiontrue
 		
 	}{}
 	
@@ -1638,7 +1730,9 @@
 			\draw [Dspring] ($(#2)+1*(0,0,-\DhingeAxialHeight/2.5)$)-- ++(0,0,-\DsupportLength*#5+\DhingeAxialHeight/2);
 			\filldraw [normalLine,fill=white] ($(#2)+1*(0,0,-\DsupportLength*#5)$) circle (\DhingeRadius);
 		}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}	
+        \ifthenelse{\boolean{STNL@ValidCommandTypeOption}}{}{\errmessage{stanli::dsupport: Bad type: #1}\errorstopmode}
 }
 
 %------------------------------------------------
@@ -1660,11 +1754,13 @@
 %						
 
 \newcommandx{\dhinge}[5][3=0,4=0,5=0]{
+  \global\STNL@ValidCommandTypeOptionfalse
 	\ifthenelse{\equal{#1}{1}}{		%
 		\begin{scope}[rotate around={#3:(#2)}]
 			\fill [white] (#2) circle (\DhingeRadius);
 			\draw [normalLine] (#2) circle (\DhingeRadius);
 		\end{scope} 
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{2}}{		%
@@ -1678,6 +1774,7 @@
 			\filldraw [fill=white,normalLine] (#2) circle (\DhingeBigRadius);
 		\end{scope}
 		\draw[hugeLine] ($(#2)!\DhingeBigRadius!(#3)$)--(#2)--($(#2)!\DhingeBigRadius!(#4)$);
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{3}}{		%
@@ -1687,6 +1784,7 @@
 						-- ++({0*cos(#3+90)+\DhingeAxialHeight*sin(#3+90)},{0*sin(#3+90)-\DhingeAxialHeight*cos(#3+90)})
 						-- ++(0,0,\DhingeAxialLength);
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{4}}{		%
@@ -1694,7 +1792,9 @@
 		\coordinate (hingeVarB) at ($ (#2)!\DhingeCornerLength!(#4) $);
 		\fill[black] (#2) -- (hingeVarA) -- (hingeVarB) -- cycle;
 		\fill[black] (#2)circle (\DhugeLineWidth/2);
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
+        \ifthenelse{\boolean{STNL@ValidCommandTypeOption}}{}{\errmessage{stanli::dhinge: Bad type: #1}\errorstopmode}
 }
 
 %------------------------------------------------
@@ -1705,6 +1805,7 @@
 %
 
 \newcommandx{\dload}[6][3=0,4=0,5=0,6=0]{
+  \global\STNL@ValidCommandTypeOptionfalse
 	\ifthenelse{\equal{#1}{1}}{		%
 		\ifthenelse{\equal{#6}{0}}
 			{\renewcommand{\DhelpVarA}{\DforceDistance}}
@@ -1713,6 +1814,7 @@
 			{\renewcommand{\DhelpVarB}{\DforceLength}}
 			{\renewcommand{\DhelpVarB}{#5}}
 		\draw[force,<-] ($(#2)+1*({\DhelpVarA*cos(#4)*sin(#3)},{\DhelpVarA*sin(#4)*sin(#3)},{\DhelpVarA*cos(#3)})$) --++({\DhelpVarB*cos(#4)*sin(#3)},{\DhelpVarB*sin(#4)*sin(#3)},{\DhelpVarB*cos(#3)});
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 		
 		
@@ -1724,6 +1826,7 @@
 			{\renewcommand{\DhelpVarB}{\DforceLength}}
 			{\renewcommand{\DhelpVarB}{#5}}
 		\draw[force,->] ($(#2)+1*({\DhelpVarA*cos(#4)*sin(#3)},{\DhelpVarA*sin(#4)*sin(#3)},{\DhelpVarA*cos(#3)})$) --++({\DhelpVarB*cos(#4)*sin(#3)},{\DhelpVarB*sin(#4)*sin(#3)},{\DhelpVarB*cos(#3)});
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 		
 	\ifthenelse{\equal{#1}{3}}{		%
@@ -1734,6 +1837,7 @@
 			{\renewcommand{\DhelpVarB}{\DforceLength}}
 			{\renewcommand{\DhelpVarB}{#5}}
 		\draw[force,<<-] ($(#2)+1*({\DhelpVarA*cos(#4)*sin(#3)},{\DhelpVarA*sin(#4)*sin(#3)},{\DhelpVarA*cos(#3)})$) --++({\DhelpVarB*cos(#4)*sin(#3)},{\DhelpVarB*sin(#4)*sin(#3)},{\DhelpVarB*cos(#3)});
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 		
 	\ifthenelse{\equal{#1}{4}}{		%
@@ -1744,7 +1848,9 @@
 			{\renewcommand{\DhelpVarB}{\DforceLength}}
 			{\renewcommand{\DhelpVarB}{#5}}
 		\draw[force,->>] ($(#2)+1*({\DhelpVarA*cos(#4)*sin(#3)},{\DhelpVarA*sin(#4)*sin(#3)},{\DhelpVarA*cos(#3)})$) --++({\DhelpVarB*cos(#4)*sin(#3)},{\DhelpVarB*sin(#4)*sin(#3)},{\DhelpVarB*cos(#3)});
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
+        \ifthenelse{\boolean{STNL@ValidCommandTypeOption}}{}{\errmessage{stanli::dload: Bad type: #1}\errorstopmode}
 	
 }
 
@@ -1800,6 +1906,7 @@
 }
 
 \newcommandx{\sublineload}[9][4=1,5=1,6=\DlineloadInterval,7=\DlineloadInterval,8=0,9=0]{
+  \global\STNL@ValidCommandTypeOptionfalse
 	\ifthenelse{\equal{#1}{1}}{		%
 		\coordinate (lineloadVarA1) at ($ (#2)!\DlineloadDistanceMM!90:(#3) $);
 		\coordinate (lineloadVarB1) at ($ (#3)!\DlineloadDistanceMM!-90:(#2) $);
@@ -1822,6 +1929,7 @@
 			\pgfmathsetmacro{\lineloadIntervalEnd}{1-#6/\DscalingParameter}
 		\foreach \i in {\lineloadIntervalBegin,\lineloadIntervalStep,...,\lineloadIntervalEnd}
 		\draw [force,->] ($(lineloadVarA2)!\i!(lineloadVarB2)$)-- ($(lineloadVarA1)!\i!(lineloadVarB1)$);
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{2}}{		%
@@ -1846,6 +1954,7 @@
 			\pgfmathsetmacro{\lineloadIntervalEnd}{1-#6}
 		\foreach \i in {\lineloadIntervalBegin,\lineloadIntervalStep,...,\lineloadIntervalEnd}
 		\draw [force,->] ($(lineloadVarA2)!\i!(lineloadVarB2)$)-- ($(lineloadVarA1)!\i!(lineloadVarB1)$);
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
 	\ifthenelse{\equal{#1}{3}}{		%
@@ -1880,6 +1989,7 @@
 			\pgfmathsetmacro{\lineloadIntervalEnd}{1-#7}
 		\foreach \i in {\lineloadIntervalBegin,\lineloadIntervalStep,...,\lineloadIntervalEnd}
 		\draw [force,->] ($(lineloadVarA2)!\i!(lineloadVarB2)$)-- ($(lineloadVarA1)!\i!(lineloadVarB1)$);
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{4}}{		%
@@ -1895,6 +2005,7 @@
 			{\pgfmathsetmacro{\lineloadForceLength}{#5}}
 		\foreach \i in {0,\lineloadIntervalStep,...,\lineloadIntervalEnd}
 		\draw [force,->] ($(lineloadVarA1)!\i!(lineloadVarB1)$) -- ($(lineloadVarA1)!\i+\lineloadForceLength!(lineloadVarB1)$);
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
 \ifthenelse{\equal{#1}{5}}{		%
@@ -1919,6 +2030,7 @@
 			\pgfmathsetmacro{\lineloadIntervalEnd}{1-#6/\DscalingParameter}
 		\foreach \i in {\lineloadIntervalBegin,\lineloadIntervalStep,...,\lineloadIntervalEnd}
 		\draw [force,->] ($(lineloadVarA2)!\i!(lineloadVarB2)$)-- ($(lineloadVarA1)!\i!(lineloadVarB1)$);
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
 
@@ -1935,7 +2047,9 @@
 			{\pgfmathsetmacro{\lineloadForceLength}{#5}}
 		\foreach \i in {0,\lineloadIntervalStep,...,\lineloadIntervalEnd}
 		\draw [force,->] ($(lineloadVarA1)!\i!(lineloadVarB1)$) -- ($(lineloadVarA1)!\i+\lineloadForceLength!(lineloadVarB1)$);
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
+        \ifthenelse{\boolean{STNL@ValidCommandTypeOption}}{}{\errmessage{stanli::dlineload: Bad type: #1}\errorstopmode}
 
 }
 
@@ -2076,10 +2190,12 @@
 %						
 
 \newcommandx{\dnotation}[7][4=above right,5=.5,6=above,7=sloped]{
+  \global\STNL@ValidCommandTypeOptionfalse
 	\ifthenelse{\equal{#1}{1}}{
 		\begin{scope}
 			\draw (#2) node [#4]{#3};
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{2}}{
@@ -2087,6 +2203,7 @@
 		\draw (#2) node [#4]{#3};
 		\draw[bigLine] (#2)--++(0,\DdimensioningBar/2)--++(0,-\DdimensioningBar);
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{3}}{
@@ -2095,6 +2212,7 @@
 		\coordinate (notationVarB2) at ($ (notationVarA1)!\DdimensioningBar/2!-90:(#3) $);
 		\draw[bigLine] (notationVarB1)--(notationVarB2);
 		\draw (notationVarA1) node [#6]{#4};
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 		
 	\ifthenelse{\equal{#1}{4}}{
@@ -2104,6 +2222,7 @@
 		\begin{scope}
 		\path (#2) -- (#3) node[inner sep=0mm,rectangle,smallLine,fill=white,draw,minimum size=2.5*\DnoteRadius,midway,#6,\DhelpVarB,pos=#5] {#4};
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}	
 	
 	\ifthenelse{\equal{#1}{5}}{
@@ -2113,13 +2232,16 @@
 		\begin{scope}
 		\path (#2) -- (#3) node[midway,#6,\DhelpVarB,pos=#5] {#4};
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 
 	\ifthenelse{\equal{#1}{6}}{
 		\begin{scope}
 		\draw (#2) node [inner sep=0mm,circle,smallLine,fill=white,draw,minimum size=2.5*\DnoteRadius]{#3};
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
+        \ifthenelse{\boolean{STNL@ValidCommandTypeOption}}{}{\errmessage{stanli::dnotation: Bad type: #1}\errorstopmode}
 	
 }
 
@@ -2159,12 +2281,14 @@
 }
 
 \newcommandx{\subaddon}[5][5=1]{
+  \global\STNL@ValidCommandTypeOptionfalse
 	\ifthenelse{\equal{#1}{1}}{
 		\coordinate (addonVarA1) at ($ (#2)!#4!(#3) $);
 		\coordinate (addonVarB1) at ($ (addonVarA1)!\DaddonLength/2!45:(#3) $);
 		\coordinate (addonVarB2) at ($ (addonVarA1)!\DaddonLength/2!225:(#3) $);
 		\draw[smallLine] (addonVarB1)--(addonVarB2)
 		($(addonVarB1)+1*(\DsupportGap,0)$)--($(addonVarB2)+1*(\DsupportGap,0)$);
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{2}}{
@@ -2181,6 +2305,7 @@
 		}
 		\draw[smallLine] (addonVarA1)--(addonVarC1)-- (addonVarB1);
 		\filldraw (addonVarD1) circle (\DsmallLineWidth);
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
 	
 	\ifthenelse{\equal{#1}{3}}{
@@ -2194,7 +2319,9 @@
 			\draw [smallLine] (#2) circle (\DaddonLength)
 												(#2) circle (\DaddonLength-\DnormalLineWidth-\DnormalLineWidth);
 		\end{scope}
+                \global\STNL@ValidCommandTypeOptiontrue
 	}{}
+        \ifthenelse{\boolean{STNL@ValidCommandTypeOption}}{}{\errmessage{stanli::daddon: Bad type: #1}\errorstopmode}
 	
 }
 


### PR DESCRIPTION
Hi again, Jürgen

One problem I am having with stanli.sty is that when wrong type is passed to a library element this element is silently ignored without any warning. It is just not shown, and in complex drawings this may even get unnoticed.

I have been thinking about this and want to propose a type error handling mechanism to trigger errors in these cases. It deals only with 'major type'.

In this implementation, a single boolean is used, it is reset at command start and trued if a valid option is passed. At command end, its value is checked and an error triggered for no valid option passed, together with some info, like in this example

`! stanli::support: Bad type: 1bad.
<argument> ...ge {stanli::support: Bad type: 1bad}
                                                  \errorstopmode 
l.43 	\support{1bad}{f};
                        
?`

An alternative would be to nest definitions and trigger an error if no tests matches, but I think this would make code way harder to read in long definitions.

Regards,