### PR TITLE
Update \point command

### DIFF
--- a/stanli.sty
+++ b/stanli.sty
@@ -263,7 +263,7 @@
 
 \newcommandx{\point}[3]{
 	\node[coordinate][
-		shift={(#2*\scalingParameter,#3*\scalingParameter)}](#1){};
+		shift={({#2*\scalingParameter},{#3*\scalingParameter})}](#1){};
 }
 
 %------------------------------------------------


### PR DESCRIPTION
When defining a point I noticed that I could use sine in only one of the coordinate values at the time but not both

For example: 
\point{a}{1}{sin(15)} and \point{a}{cos(15)}{1} would work but \point{a}{cos(15)}{sin(15)} doesn't.

This change fixes that issue